### PR TITLE
Add Welsh Localisation

### DIFF
--- a/ee3_common/ee3/common/lib/Localizations.java
+++ b/ee3_common/ee3/common/lib/Localizations.java
@@ -14,6 +14,7 @@ public class Localizations {
 	private static final String LANG_RESOURCE_LOCATION = "/ee3/lang/";
 	
 	public static String[] localeFiles = {
+		LANG_RESOURCE_LOCATION + "cy_GB.xml",
 		LANG_RESOURCE_LOCATION + "en_US.xml",
 		LANG_RESOURCE_LOCATION + "nl_NL.xml"
 	};

--- a/resources/ee3/lang/cy_GB.xml
+++ b/resources/ee3/lang/cy_GB.xml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
+<properties version="1.0">
+	<comment>Welsh Localization File</comment>
+	<entry key="item.miniumShard.name">Darn o Finiwm</entry>
+	<entry key="item.miniumStone.name">Carreg Miniwm</entry>
+	<entry key="item.philStone.name">Maen Athronwyr</entry>
+	<entry key="tile.redWaterStill.name">Dŵr Coch (Llonydd)</entry>
+	<entry key="tile.redWaterFlowing.name">Dŵr Coch (Llifeiriol)</entry>
+	<entry key="tile.calcinator.name">Calchyniadwr</entry>
+	<entry key="version.uninitialized">Heb Ymgychwyn</entry>
+	<entry key="version.current">Cyfredol</entry>
+	<entry key="version.outdated">Wedi Dyddio</entry>
+	<entry key="version.connection_error">Gwall Cysylltiad</entry>
+</properties>


### PR DESCRIPTION
I'm assuming the localeFiles array should be in alphabetical order in Localizations.java, so cy_GB.xml is above en_US.xml there.

As with the Dutch translation, I used the Welsh name of the first Harry Potter book for the stone's name here. However the book uses singular "Philosopher's" whereas EE uses plural "Philosophers" without the apostrophe. I'm not sure if that was a long-time-ago typo in EE, but I'm using the plural version in this translation as that's how the item is named in EE's default en_US.xml.
