### PR TITLE
Reworked build.xml for 1.3.2

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -3,6 +3,9 @@
 	
 	<!-- Set some default properties -->
 	<property name="dir.development" value="../../" />
+	<property name="release.minecraft.version" value="1.3.2" /> <!-- Update when EE3 is updated to a newer MC version -->
+	<property name="release.mod.version" value="0.0.1dev" /> <!-- Update when EE3 is updated to a newer version -->
+	<property name="dir.beta" value="${dir.development}/beta" /> <!-- Update when EE3 is updated to a newer version -->
 	<!-- Read properties from build.properties, if it exists -->
 	<property file="build.properties" />
 	
@@ -102,13 +105,13 @@
 				<fileset dir="${dir.development}\mcp\reobf\minecraft" />
 				<fileset dir="${dir.development}\source\Equivalent-Exchange-3\resources" />
 			</jar>
-			<jar destfile="${dir.development}\releases\ee3-server-v${release.mod.version}.jar" basedir="${dir.development}\mcp\reobf\minecraft_server" />
+			<!--TODO Fix server jar if neccessary for 1.3.2 -->
+			<!--<jar destfile="${dir.development}\releases\ee3-server-v${release.mod.version}.jar" basedir="${dir.development}\mcp\reobf\minecraft_server" /> -->
 		
 			<!-- Put a copy in pahimar's Beta DB share if ${dir.beta} is defined-->
-			<condition property="dir.beta.set" else="false">
-			      <isset property="dir.beta"/>
-			</condition>
-			<antcall target="copy-to-beta-share" />
+			<mkdir dir="${dir.beta}\${release.minecraft.version}\${release.mod.version}" />
+			<copy file="${dir.development}\releases\ee3-client-v${release.mod.version}.jar" todir="${dir.beta}\${release.minecraft.version}\${release.mod.version}" />
+			<!--<move file="${dir.development}\releases\ee3-server-v${release.mod.version}.jar" todir="${dir.beta}\${release.minecraft.version}\${release.mod.version}" />-->
 
 			<!-- Clean up the MCP source now that we are done -->
 			<antcall target="clean" />
@@ -134,43 +137,19 @@
 			<fileset dir="${dir.development}\mcp\reobf\minecraft" />
 			<fileset dir="${dir.development}\source\Equivalent-Exchange-3\resources" />
 		</jar>
-		<jar destfile="${dir.development}\releases\ee3-server-v${release.mod.version}.jar" basedir="${dir.development}\mcp\reobf\minecraft_server" />
+		<!--<jar destfile="${dir.development}\releases\ee3-server-v${release.mod.version}.jar" basedir="${dir.development}\mcp\reobf\minecraft_server" />-->
 		
 		<!-- Put a copy in Sengir's DB share -->
-		<condition property="dir.beta.set" else="false">
-			      <isset property="dir.share"/>
-		</condition>
-		<antcall target="copy-to-sengir-share" />
+		<mkdir dir="${dir.share}\${release.minecraft.version}\${release.mod.version}" />
+		<copy file="${dir.development}\releases\ee3-client-v${release.mod.version}.jar" todir="${dir.share}\${release.minecraft.version}\${release.mod.version}" />
+		<!--<copy file="${dir.development}\releases\ee3-server-v${release.mod.version}.jar" todir="${dir.share}\${release.minecraft.version}\${release.mod.version}" />-->
 		
 		<!-- Put a copy in my public DB share -->
-		<condition property="dir.release.set" else="false">
-			      <isset property="dir.release"/>
-		</condition>
-		<antcall target="copy-to-public-share" />
+		<mkdir dir="${dir.release}\${release.minecraft.version}\${release.mod.version}" />
+		<copy file="${dir.development}\releases\ee3-client-v${release.mod.version}.jar" todir="${dir.release}\${release.minecraft.version}\${release.mod.version}" />
+		<!--<copy file="${dir.development}\releases\ee3-server-v${release.mod.version}.jar" todir="${dir.release}\${release.minecraft.version}\${release.mod.version}" />-->
 		
 		<!-- Clean up the MCP source now that we are done -->
 		<antcall target="clean" />
 	</target>
-		
-	<!-- Put a copy in pahimar's Beta DB share if ${dir.beta} is defined-->
-	<target name="copy-to-beta-share" if="dir.beta.set">
-		<mkdir dir="${dir.beta}\${release.minecraft.version}\${release.mod.version}" />
-		<move file="${dir.development}\releases\ee3-client-v${release.mod.version}.jar" todir="${dir.beta}\${release.minecraft.version}\${release.mod.version}" />
-		<move file="${dir.development}\releases\ee3-server-v${release.mod.version}.jar" todir="${dir.beta}\${release.minecraft.version}\${release.mod.version}" />
-	</target>	
-	
-	<!-- Put a copy in Sengir's DB share if ${dir.share} is defined-->
-	<target name="copy-to-sengir-share" if="dir.share.set">
-		<mkdir dir="${dir.share}\${release.minecraft.version}\${release.mod.version}" />
-		<copy file="${dir.development}\releases\ee3-client-v${release.mod.version}.jar" todir="${dir.share}\${release.minecraft.version}\${release.mod.version}" />
-		<copy file="${dir.development}\releases\ee3-server-v${release.mod.version}.jar" todir="${dir.share}\${release.minecraft.version}\${release.mod.version}" />
-	</target>
-	
-	<!-- Put a copy in Sengir's DB share if ${dir.share} is defined-->
-	<target name="copy-to-public-share" if="dir.share.set">
-		<mkdir dir="${dir.release}\${release.minecraft.version}\${release.mod.version}" />
-		<copy file="${dir.development}\releases\ee3-client-v${release.mod.version}.jar" todir="${dir.release}\${release.minecraft.version}\${release.mod.version}" />
-		<copy file="${dir.development}\releases\ee3-server-v${release.mod.version}.jar" todir="${dir.release}\${release.minecraft.version}\${release.mod.version}" />
-	</target>
-	
 </project>


### PR DESCRIPTION
With this patch, build.xml works for 1.3.2 now. Additionally, I introduced default values for the most common properties in build.xml (because there is no default build.properties) so anyone can compile EE3 more easily.

Additionally, I introduced a "start" target executing the startclient.sh/.cmd script from the MCP package. This could make it more easy to test and debug EE3.

I didn't test if the mod jars generated by release-beta and release-final generate valid FML-compatible mod jars -- I only tested if ant puts them in the right place.
