### PR TITLE
Fixing self-submitted portable smelting issue.

### DIFF
--- a/ee3_common/ee3/common/core/helper/RecipeHelper.java
+++ b/ee3_common/ee3/common/core/helper/RecipeHelper.java
@@ -142,7 +142,7 @@ public class RecipeHelper {
         for (int i = 2; i < 9; i++)
             list[i] = new ItemStack(input.getItem(), 1, input.getItemDamage());
 
-        GameRegistry.addShapelessRecipe(new ItemStack(result.getItem(), 7, result.getItemDamage()), list);
+        GameRegistry.addShapelessRecipe(new ItemStack(result.getItem(), (result.stackSize*7), result.getItemDamage()), list);
     }
     
 }


### PR DESCRIPTION
Auto-detected portable smelting recipes should now take into account the output number of the recipe.

Example here (Wheat Block smelts to 3 Bread each) : http://puu.sh/1nuLD
