### PR TITLE
Compatibility for mods with large-result smelting recipes

### DIFF
--- a/ee3_common/ee3/common/core/helper/RecipeHelper.java
+++ b/ee3_common/ee3/common/core/helper/RecipeHelper.java
@@ -135,14 +135,19 @@ public class RecipeHelper {
         if (result == null)
             return;
 
-        Object[] list = new Object[9];
+        int recipeLength = 9;
+        int stackNum = (int)Math.floor(64 / result.stackSize);
+        if(stackNum<7) recipeLength = (stackNum)+2;
+        if(recipeLength>9) recipeLength = 9;
+        
+        Object[] list = new Object[recipeLength];
         list[0] = stone;
         list[1] = fuel;
 
-        for (int i = 2; i < 9; i++)
-            list[i] = new ItemStack(input.getItem(), 1, input.getItemDamage());
+        for (int i = 2; i < recipeLength; i++)
+            list[i] = new ItemStack(input.getItem(), 1, input.getItemDamage()); 
 
-        GameRegistry.addShapelessRecipe(new ItemStack(result.getItem(), (result.stackSize*7), result.getItemDamage()), list);
+        GameRegistry.addShapelessRecipe(new ItemStack(result.getItem(), (result.stackSize*(recipeLength-2)), result.getItemDamage()), list);
     }
     
 }


### PR DESCRIPTION
The automatic portable furnace recipes will now check if the resulting transmutation recipe would produce a stack higher than 64. If so, the code will dynamically reduce the amount of smeltable items used in recipe.

Example: http://puu.sh/1nwtq 
(I made the block smelt into 10 Stone as a test of this functionality) 

Please make sure to inform me if this is not a preferable solution.
