### PR TITLE
Added a README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ## Welcome to Equivalent Exchange 3!
 The Compilation part (Setup) was done mostly by Minalien, I just changed it a bit.  Some credit goes to BuildCraft's README.md, which I based this README off of.
+
 The Minecraft Forums page can be found [here] (www.minecraftforum.net/topic/1540010-equivalent-exchange-3).
 
 ### Compiling Equivalent Exchange 3


### PR DESCRIPTION
Added a README.md for Equivalent Exchange 3, thought it would be nice.  Included in it are the Minecraft Forums page for EE3, and how to compile it.  Credit goes to Minalien who created the wiki page for Compiling EE3, and BuildCraft's README.md, which gave me the layout for EE3's.  I merely copied everything into the README, and changed some minor things.
