### PR TITLE
Update/fix build.xml

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -2,6 +2,9 @@
 <project name="Equivalent Exchange 3">
 	
 	<property file="build.properties" />
+	<property name="dir.release"	value="Releases"/>  <!-- Or whatever you want to call it~ -->
+	<property name="mc.version"	value="1.4.5"/>
+	<property name="ee3.version"	value="pre2"/> <!-- Or whatever version you want -->
 	
 	<target name="clean">
 		<delete file="${dir.development}\mcp\src\common\mcmod.info" />
@@ -14,7 +17,7 @@
 			<fileset dir="${dir.development}\source\Equivalent-Exchange-3\ee3_client\" />
 			<fileset dir="${dir.development}\source\Equivalent-Exchange-3\ee3_common\" />
 		</copy>
-		<replace dir="${dir.development}\mcp\src\common" token="@VERSION@" value="${release.mod.version}" />
+		<replace dir="${dir.development}\mcp\src\common" token="@VERSION@" value="${ee3.version}" />
 	</target>
 	
 	<target name="recompile">
@@ -43,8 +46,8 @@
 		<antcall target="reobfuscate" />
 		
 		<!-- Build the jar -->
-		<mkdir dir="${dir.share}\${release.minecraft.version}\${release.mod.version}" />
-		<jar destfile="${dir.share}\${release.minecraft.version}\${release.mod.version}\ee3-universal-${release.mod.version}.jar">
+		<mkdir dir="${dir.share}\${mc.version}\${ee3.version}" />
+		<jar destfile="${dir.share}\${mc.version}\${ee3.version}\ee3-universal-${ee3.version}.jar">
 			<fileset dir="${dir.development}\mcp\src\common\"	includes="mcmod.info" />
 			<fileset dir="${dir.development}\mcp\reobf\minecraft" />
 			<fileset dir="${dir.development}\source\Equivalent-Exchange-3\resources" />
@@ -62,8 +65,8 @@
 		<antcall target="reobfuscate" />
 		
 		<!-- Build the jar -->
-		<mkdir dir="${dir.release}\${release.minecraft.version}\${release.mod.version}" />
-		<jar destfile="${dir.release}\${release.minecraft.version}\${release.mod.version}\ee3-universal-${release.mod.version}.jar">
+		<mkdir dir="${dir.release}\${mc.version}\${ee3.version}" />
+		<jar destfile="${dir.release}\${mc.version}\${ee3.version}\ee3-universal-${ee3.version}.jar">
 			<fileset dir="${dir.development}\mcp\src\common\"	includes="mcmod.info" />
 			<fileset dir="${dir.development}\mcp\reobf\minecraft" />
 			<fileset dir="${dir.development}\source\Equivalent-Exchange-3\resources" />


### PR DESCRIPTION
When I did `ant release -Ddir.development=../../`, I did find the .jar file (yay!), but the folder format was horrendous.  `${dir.release}`, `${release.minecraft.version}`, and `${release.mod.version}` had no values assigned to them, so I added values.  In addition, `Release.minecraft.version` was changed to `mc.version`, and `release.mod.version` was changed to `ee3.version`.

More changes coming later?
