### PR TITLE
Fix EE3+NetherOres+PetroGen startup crash

### DIFF
--- a/ee3_common/com/pahimar/ee3/core/helper/RecipeHelper.java
+++ b/ee3_common/com/pahimar/ee3/core/helper/RecipeHelper.java
@@ -143,7 +143,7 @@ public class RecipeHelper {
 
         ItemStack result = FurnaceRecipes.smelting().getSmeltingResult(input);
 
-        if (result == null)
+        if ((input == null) || (input.getItem() == null) || (result == null))
             return;
 
         Object[] list = new Object[9];


### PR DESCRIPTION
Okay, here's a weird edge case for you: if EE3, [PetroGen](http://forum.industrial-craft.net/index.php?page=Thread&threadID=8385), and [Nether Ores](http://atomicstryker.net/netherores.html) are all present at the same time, this somehow changes the load order just enough so that EE3 attempts to register a transmutation smelting recipe for the nether ores, which fails because the item stack passed in as _input_ returns null from its getItem(), [making it impossible to initialize another ItemStack](http://pastebin.com/K6ZLk3Ps). If you remove PetroGen, the crash no longer happens and the nether ores no longer try to register in EE3's transmutation smelts.

The strangest thing is the mod load order reported by FML still puts EE3 far above NetherOres, which makes the fact that ItemStack.getItem() fails somewhat reasonable -- but how is PetroGen registering it as a smelting recipe when there's nowhere in the code that has anything to do with smelting? One of the great mysteries of life.

Either way, ignoring smelting recipes with null input or null input.getItem() fixes the issue. Also, that was a really terrible way to spend two hours just now.
