### PR TITLE
Make GeneralHelper.isHostileEntity apply to all mobs

### DIFF
--- a/ee3_common/com/pahimar/ee3/core/helper/GeneralHelper.java
+++ b/ee3_common/com/pahimar/ee3/core/helper/GeneralHelper.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 
 import net.minecraft.block.Block;
 import net.minecraft.entity.EntityLiving;
-import net.minecraft.entity.monster.EntityMob;
+import net.minecraft.entity.monster.IMob;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
@@ -50,7 +50,7 @@ public class GeneralHelper {
 
     public static boolean isHostileEntity(EntityLiving entity) {
 
-        if (entity instanceof EntityMob) {
+        if (entity instanceof IMob) {
             return true;
         }
         else {


### PR DESCRIPTION
Not all mobs extend EntityMob (e.g. Ghasts), the interface IMob, trough, encompasses all mobs.
