### PR TITLE
Updated to newer forge and slight change to transmuting

### DIFF
--- a/ee3_common/com/pahimar/ee3/core/handlers/ItemEventHandler.java
+++ b/ee3_common/com/pahimar/ee3/core/handlers/ItemEventHandler.java
@@ -24,22 +24,22 @@ public class ItemEventHandler {
     @ForgeSubscribe
     public void onItemPickup(EntityItemPickupEvent event) {
 
-        if (NBTHelper.hasTag(event.item.getEntityItem(), Strings.NBT_ITEM_CRAFTING_GUI_OPEN)) {
-            NBTHelper.removeTag(event.item.getEntityItem(), Strings.NBT_ITEM_CRAFTING_GUI_OPEN);
+        if (NBTHelper.hasTag(event.item.func_92014_d(), Strings.NBT_ITEM_CRAFTING_GUI_OPEN)) {
+            NBTHelper.removeTag(event.item.func_92014_d(), Strings.NBT_ITEM_CRAFTING_GUI_OPEN);
         }
-        else if (NBTHelper.hasTag(event.item.getEntityItem(), Strings.NBT_ITEM_TRANSMUTATION_GUI_OPEN)) {
-            NBTHelper.removeTag(event.item.getEntityItem(), Strings.NBT_ITEM_TRANSMUTATION_GUI_OPEN);
+        else if (NBTHelper.hasTag(event.item.func_92014_d(), Strings.NBT_ITEM_TRANSMUTATION_GUI_OPEN)) {
+            NBTHelper.removeTag(event.item.func_92014_d(), Strings.NBT_ITEM_TRANSMUTATION_GUI_OPEN);
         }
     }
 
     @ForgeSubscribe
     public void onItemToss(ItemTossEvent event) {
 
-        if (NBTHelper.hasTag(event.entityItem.getEntityItem(), Strings.NBT_ITEM_CRAFTING_GUI_OPEN)) {
-            NBTHelper.removeTag(event.entityItem.getEntityItem(), Strings.NBT_ITEM_CRAFTING_GUI_OPEN);
+        if (NBTHelper.hasTag(event.entityItem.func_92014_d(), Strings.NBT_ITEM_CRAFTING_GUI_OPEN)) {
+            NBTHelper.removeTag(event.entityItem.func_92014_d(), Strings.NBT_ITEM_CRAFTING_GUI_OPEN);
         }
-        else if (NBTHelper.hasTag(event.entityItem.getEntityItem(), Strings.NBT_ITEM_TRANSMUTATION_GUI_OPEN)) {
-            NBTHelper.removeTag(event.entityItem.getEntityItem(), Strings.NBT_ITEM_TRANSMUTATION_GUI_OPEN);
+        else if (NBTHelper.hasTag(event.entityItem.func_92014_d(), Strings.NBT_ITEM_TRANSMUTATION_GUI_OPEN)) {
+            NBTHelper.removeTag(event.entityItem.func_92014_d(), Strings.NBT_ITEM_TRANSMUTATION_GUI_OPEN);
         }
     }
 
@@ -47,11 +47,11 @@ public class ItemEventHandler {
     public void onPlayerDrop(PlayerDropsEvent event) {
 
         for (EntityItem entityItem : event.drops) {
-            if (NBTHelper.hasTag(entityItem.getEntityItem(), Strings.NBT_ITEM_CRAFTING_GUI_OPEN)) {
-                NBTHelper.removeTag(entityItem.getEntityItem(), Strings.NBT_ITEM_CRAFTING_GUI_OPEN);
+            if (NBTHelper.hasTag(entityItem.func_92014_d(), Strings.NBT_ITEM_CRAFTING_GUI_OPEN)) {
+                NBTHelper.removeTag(entityItem.func_92014_d(), Strings.NBT_ITEM_CRAFTING_GUI_OPEN);
             }
-            else if (NBTHelper.hasTag(entityItem.getEntityItem(), Strings.NBT_ITEM_TRANSMUTATION_GUI_OPEN)) {
-                NBTHelper.removeTag(entityItem.getEntityItem(), Strings.NBT_ITEM_TRANSMUTATION_GUI_OPEN);
+            else if (NBTHelper.hasTag(entityItem.func_92014_d(), Strings.NBT_ITEM_TRANSMUTATION_GUI_OPEN)) {
+                NBTHelper.removeTag(entityItem.func_92014_d(), Strings.NBT_ITEM_TRANSMUTATION_GUI_OPEN);
             }
         }
     }

--- a/ee3_common/com/pahimar/ee3/core/helper/TransmutationHelper.java
+++ b/ee3_common/com/pahimar/ee3/core/helper/TransmutationHelper.java
@@ -33,6 +33,7 @@ public class TransmutationHelper {
 
         if (Block.blocksList[targetID] != null) {
             world.setBlockAndMetadataWithNotify(x, y, z, targetID, targetMeta);
+            stack.setItemDamage(stack.getItemDamage() + 1);
             return true;
         }
 

--- a/ee3_common/com/pahimar/ee3/item/ItemMiniumStone.java
+++ b/ee3_common/com/pahimar/ee3/item/ItemMiniumStone.java
@@ -74,6 +74,7 @@ public class ItemMiniumStone extends ItemEE
 
         if (world.isRemote) {
             transmuteBlock(itemStack, entityPlayer, world, x, y, z, sideHit);
+            
         }
         return true;
     }


### PR DESCRIPTION
Updated to work on a newer version of Forge(6.6.0.497 to be exact) and changed so that transmuting blocks by right clicking damages the stone, to keep people from keeping their stone healthy by not transmuting in a crafting table(a bit poorly worded, but I couldn't think of a better explanation, plus it's a very small change, you should be able to figure it out yourself).
