### PR TITLE
Letting arrow death work

### DIFF
--- a/ee3_common/com/pahimar/ee3/core/handlers/EntityLivingHandler.java
+++ b/ee3_common/com/pahimar/ee3/core/handlers/EntityLivingHandler.java
@@ -28,6 +28,13 @@ public class EntityLivingHandler {
 
         if (event.source.getDamageType().equals("player")) {
             ItemDropHelper.dropMiniumShard((EntityPlayer) event.source.getSourceOfDamage(), event.entityLiving);
+        }    	
+        if (event.source.getSourceOfDamage() instanceof EntityArrow){
+            if (((EntityArrow) event.source.getSourceOfDamage()).shootingEntity != null){
+                if (((EntityArrow) event.source.getSourceOfDamage()).shootingEntity instanceof EntityPlayer){
+                	ItemDropHelper.dropMiniumShard((EntityPlayer) event.source.getSourceOfDamage(), event.entityLiving);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
makes it so that when mobs killed with a bow have a chance of dropping minium shards.
