### PR TITLE
Fix for Alchemical Bag Shift-Click Crash

### DIFF
--- a/ee3_common/com/pahimar/ee3/inventory/ContainerAlchemicalBag.java
+++ b/ee3_common/com/pahimar/ee3/inventory/ContainerAlchemicalBag.java
@@ -34,7 +34,10 @@ public class ContainerAlchemicalBag extends Container {
             this.addSlotToContainer(new Slot(inventoryPlayer, actionBarSlotIndex, 44 + actionBarSlotIndex * 18, 162));
         }
     }
-
+    @Override
+    public void retrySlotClick(int par1, int par2, boolean par3, EntityPlayer par4EntityPlayer) { 
+    	//Prevents Bag Shift-Click Crash By Overriding retrySlotClick(). Not A Great Solution, Will Improve Soon 
+    }
     @Override
     public boolean canInteractWith(EntityPlayer var1) {
 


### PR DESCRIPTION
This just overrides retrySlotClick() and is an empty method, therefore
doing nothing. I believe this is the method that gets called when an
item is shift clicked into a container. I know that this isn't a great
fix but I'm working on a better one.
