### PR TITLE
Crash fix of LivingHandler

### DIFF
--- a/ee3_common/com/pahimar/ee3/core/handlers/EntityLivingHandler.java
+++ b/ee3_common/com/pahimar/ee3/core/handlers/EntityLivingHandler.java
@@ -33,7 +33,7 @@ public class EntityLivingHandler {
         if (event.source.getSourceOfDamage() instanceof EntityArrow) {
             if (((EntityArrow) event.source.getSourceOfDamage()).shootingEntity != null) {
                 if (((EntityArrow) event.source.getSourceOfDamage()).shootingEntity instanceof EntityPlayer) {
-                    ItemDropHelper.dropMiniumShard((EntityPlayer) event.source.getSourceOfDamage(), event.entityLiving);
+                    ItemDropHelper.dropMiniumShard((EntityPlayer) ((EntityArrow)event.source.getSourceOfDamage()).shootingEntity, event.entityLiving);
                 }
             }
         }


### PR DESCRIPTION
I've fixed a crash, occurring when a mob was shot with a bow, by a player.
