### PR TITLE
Transformation bug involving metadata

### DIFF
--- a/ee3_common/com/pahimar/ee3/core/helper/TransmutationHelper.java
+++ b/ee3_common/com/pahimar/ee3/core/helper/TransmutationHelper.java
@@ -28,7 +28,7 @@ public class TransmutationHelper {
     public static boolean transmuteInWorld(World world, EntityPlayer player, ItemStack stack, int x, int y, int z, int targetID, int targetMeta) {
 
         if (Block.blocksList[targetID] != null) {
-            world.setBlockMetadataWithNotify(x, y, z, targetID, targetMeta);
+            world.setBlock(x, y, z, targetID, targetMeta, 2);
             return true;
         }
 


### PR DESCRIPTION
And now in the right branch...

I found a bug that you could only transmute blocks in the world with metadata and most of the time it wouldn't even do it, and I have fixed that. All I did was to go to com.pahimar.ee3.core.helper.TransmutationHelper.transmuteInWorld() and changed the world.setBlockMetadataWithNotify(x, y, z, targetID, targetMeta); to world.setBlock(x, y, z, targetID, targetMeta, 2);. Now it works perfectly. I am sure you have already fixed this, but I wanted to have this on the repo, just for good looks.
