### PR TITLE
Changed to getUnlocalizedName2

### DIFF
--- a/ee3_common/com/pahimar/ee3/block/BlockEE.java
+++ b/ee3_common/com/pahimar/ee3/block/BlockEE.java
@@ -35,7 +35,7 @@ public abstract class BlockEE extends BlockContainer {
     @SideOnly(Side.CLIENT)
     public void registerIcons(IconRegister iconRegister) {
 
-        blockIcon = iconRegister.registerIcon(Reference.MOD_ID.toLowerCase() + ":" + this.getUnlocalizedName().substring(this.getUnlocalizedName().indexOf(".") + 1));
+        blockIcon = iconRegister.registerIcon(Reference.MOD_ID.toLowerCase() + ":" + this.getUnlocalizedName2()));
     }
 
     /**


### PR DESCRIPTION
Changed to getUnlocalizedName2 to remove the need to use substring and index of.
