### PR TITLE
Ant Buildfile, Specific OS should be replaced with OS Family

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -18,31 +18,19 @@
 	</target>
 	
 	<target name="recompile">
-		<exec dir="${dir.development}\mcp" executable="cmd" os="Windows 7">
+		<exec dir="${dir.development}\mcp" executable="cmd" osfamily="windows">
 			<arg line="/c recompile.bat" />
 		</exec>
-		<exec dir="${dir.development}\mcp" executable="cmd" os="Windows 8">
-			<arg line="/c recompile.bat" />
-		</exec>
-		<exec dir="${dir.development}\mcp" executable="bash" os="Linux">
-			<arg line="recompile.sh" />
-		</exec>
-		<exec dir="${dir.development}\mcp" executable="bash" os="Mac OS X">
+		<exec dir="${dir.development}\mcp" executable="bash" osfamily="unix">
 			<arg line="recompile.sh" />
 		</exec>
 	</target>
 	
 	<target name="reobfuscate">
-		<exec dir="${dir.development}\mcp" executable="cmd" os="Windows 7">
+		<exec dir="${dir.development}\mcp" executable="cmd" osfamily="windows">
 			<arg line="/c reobfuscate_srg.bat" />
 		</exec>
-		<exec dir="${dir.development}\mcp" executable="cmd" os="Windows 8">
-			<arg line="/c reobfuscate_srg.bat" />
-		</exec>
-		<exec dir="${dir.development}\mcp" executable="bash" os="Linux">
-			<arg line="reobfuscate_srg.sh" />
-		</exec>
-		<exec dir="${dir.development}\mcp" executable="bash" os="Mac OS X">
+		<exec dir="${dir.development}\mcp" executable="bash" osfamily="unix">
 			<arg line="reobfuscate_srg.sh" />
 		</exec>
 	</target>


### PR DESCRIPTION
 Replaced "Windows 7"/"Windows 8" with "windows" osfamily for Windows versions other than 7/8 and replace "Linux"/"Mac OS X" with "unix" osfamily for Unix OSes that aren't Linux/Mac in Ant Buildfile (build.xml).

This means that Windows versions that aren't 7 or 8 can use the buildfile, aswell as other Unix OSes (Linux & Mac OS X are classed as Unix).

It also makes the build file a bit smaller, but whatever.
