### PR TITLE
Made the hitbox of the Alchemical Chest smaller so it fits the model.

### DIFF
--- a/ee3_common/com/pahimar/ee3/block/BlockAlchemicalChest.java
+++ b/ee3_common/com/pahimar/ee3/block/BlockAlchemicalChest.java
@@ -39,6 +39,7 @@ public class BlockAlchemicalChest extends BlockEE {
 
         super(id, Material.wood);
         this.setUnlocalizedName(Strings.ALCHEMICAL_CHEST_NAME);
+        this.setBlockBounds(0.0625F, 0.0F, 0.0625F, 0.9375F, 0.875F, 0.9375F);
         this.setCreativeTab(EquivalentExchange3.tabsEE3);
     }
 


### PR DESCRIPTION
Since Minecraft 1.4.4, chests have a smaller bounding box/hitbox that fits their models. This made it possible destroy blocks under the chest, as well getting into the blank space caused by the smaller model. It also made the chests look a bit more professional and to suit the change, I've made a small change to re-size the hitbox of the Alchemical Chest.
