### PR TITLE
Philosopher's stone - world transmutation issue

### DIFF
--- a/ee3_common/com/pahimar/ee3/core/handlers/WorldTransmutationHandler.java
+++ b/ee3_common/com/pahimar/ee3/core/handlers/WorldTransmutationHandler.java
@@ -147,6 +147,12 @@ public class WorldTransmutationHandler {
         if (currentBlock != null) {
             meta = currentBlock.damageDropped(meta);
         }
+        
+        // Check if block is air, or we won't be able to transmute it.
+        if (id == 0) {
+            event.actionResult = ActionResult.FAILURE;
+            return;
+        }
 
         ItemStack worldStack = new ItemStack(id, 1, meta);
         ItemStack targetStack = new ItemStack(event.targetID, 1, event.targetMeta);


### PR DESCRIPTION
Philosopher's stone crashes when used in a grid containing a block of air. Adding a check for this should fix the issue.
