### PR TITLE
Fixes #348 and improves in world transmutation

### DIFF
--- a/ee3_common/com/pahimar/ee3/core/util/TransmutationHelper.java
+++ b/ee3_common/com/pahimar/ee3/core/util/TransmutationHelper.java
@@ -61,6 +61,7 @@ public class TransmutationHelper {
         if(currentBlockStack.getItem() == null){
             currentBlockStack = null;
         	previousBlockStack = null;
+            targetBlockStack = null;
         	return;
         }
 
@@ -69,7 +70,7 @@ public class TransmutationHelper {
             targetBlockStack = getNextBlock(currentBlockStack.itemID, currentBlockStack.getItemDamage());
         }
         else {
-            if (!EquivalencyHandler.instance().areEquivalent(TransmutationHelper.previousBlockStack, currentBlockStack)) {
+            if (previousBlockStack.itemID != currentBlockStack.itemID || previousBlockStack.getItemDamage() != currentBlockStack.getItemDamage()){
                 previousBlockStack = currentBlockStack;
                 targetBlockStack = getNextBlock(currentBlockStack.itemID, currentBlockStack.getItemDamage());
             }


### PR DESCRIPTION
Fixes https://github.com/pahimar/Equivalent-Exchange-3/issues/348

The Mystcraft writing desk apparently does not have an item registered with the same id as the block. This causes a null pointer exception to occur when you call getItemDamage() on the item stack made from hovering over the writing desk with a Minium stone.

Checking for a malformed item stack gets around this. To be honest it should probably be fixed on the Mystcraft end, but this does solve the issue.

Also improves on in world transmutation so it notices the difference between blocks that can be transmuted into each other.

Previously, the minium stone would not update its in world transmutation target when moving between two blocks that could be transmuted into each other (for example sand and cobblestone).

Now checks if the new block has a different id or damage instead.
