### PR TITLE
Timed world transmutation memory

### DIFF
--- a/ee3_common/com/pahimar/ee3/EquivalentExchange3.java
+++ b/ee3_common/com/pahimar/ee3/EquivalentExchange3.java
@@ -30,6 +30,7 @@ import com.pahimar.ee3.item.crafting.RecipesAlchemicalBagDyes;
 import com.pahimar.ee3.lib.Reference;
 import com.pahimar.ee3.lib.Strings;
 import com.pahimar.ee3.network.PacketHandler;
+import com.pahimar.ee3.recipe.RecipesTransmutationStone;
 
 import cpw.mods.fml.common.Mod;
 import cpw.mods.fml.common.Mod.FingerprintWarning;
@@ -151,7 +152,7 @@ public class EquivalentExchange3 {
         proxy.initRenderingAndTextures();
         
         // Load the Transmutation Stone recipes
-        //RecipesTransmutationStone.init();
+        RecipesTransmutationStone.init();
 
         // Add in the ability to dye Alchemical Bags
         CraftingManager.getInstance().getRecipeList().add(new RecipesAlchemicalBagDyes());

--- a/ee3_common/com/pahimar/ee3/core/util/ItemUtil.java
+++ b/ee3_common/com/pahimar/ee3/core/util/ItemUtil.java
@@ -1,6 +1,7 @@
 package com.pahimar.ee3.core.util;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 import net.minecraft.entity.EntityLiving;
@@ -24,78 +25,37 @@ import com.pahimar.ee3.lib.Strings;
 public class ItemUtil {
 
     private static double rand;
-
-    public static String toString(ItemStack itemStack) {
-
-        StringBuilder stringBuilder = new StringBuilder();
-
-        stringBuilder.append(String.format("itemID: %d, metaData: %d, stackSize: %d, itemName: %s, className: %s", itemStack.itemID, itemStack.getItemDamage(), itemStack.stackSize, itemStack.getItemName(), itemStack.getItem().getClass().toString()));
-
-        return stringBuilder.toString();
-    }
-
-    /**
-     * Compares two ItemStacks for equality, testing itemID, metaData, stackSize, and their NBTTagCompounds (if they are present)
-     * 
-     * @param first
-     *      The first ItemStack being tested for equality
-     * @param second
-     *      The second ItemStack being tested for equality
-     * @return
-     *      true if the two ItemStacks are equivalent, false otherwise
-     */
+    
     public static boolean compare(ItemStack first, ItemStack second) {
-
-        // Check to see if either argument is null
+        
         if ((first != null) && (second != null)) {
-            // Check the item IDs
             if (first.itemID == second.itemID) {
-                // Check the meta data
                 if (first.getItemDamage() == second.getItemDamage()) {
-                    // Check the stack size
-                    if (first.stackSize == second.stackSize) {
-                        // If at least one of the ItemStacks has a NBTTagCompound, test for equality
-                        if (first.hasTagCompound() || second.hasTagCompound()) {
-
-                            // If one of the stacks has a tag compound, but not both, they are not equal
-                            if (!(first.hasTagCompound() && second.hasTagCompound())) {
-                                return false;
-                            }
-                            // Otherwise, they both have tag compounds and we need to test them for equality
-                            else {
-                                return first.getTagCompound().equals(second.getTagCompound());
-                            }
-                        }
-                        // Otherwise, they must be equal if we have gotten this far (item IDs, meta data, and stack size all match)
-                        else {
-                            return true;
-                        }
-                    }
+                    return true;
                 }
             }
         }
-
+        
         return false;
     }
-
+    
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public static ArrayList collateStacks(List unCollatedStacks) {
-
         ArrayList collatedStacks = new ArrayList();
-
+        
         for (int i = 0; i < unCollatedStacks.size(); i++) {
-
+            
             if (collatedStacks.size() == 0) {
                 collatedStacks.add(unCollatedStacks.get(i));
             }
             else {
                 boolean found = false;
-
+                
                 for (int j = 0; j < collatedStacks.size(); j++) {
                     if ((unCollatedStacks.get(i) instanceof ItemStack) && (collatedStacks.get(j) instanceof ItemStack)) {
                         ItemStack unCollatedStack = (ItemStack) unCollatedStacks.get(i);
                         ItemStack collatedStack = (ItemStack) collatedStacks.get(j);
-
+                        
                         if (compare(unCollatedStack, collatedStack)) {
                             ((ItemStack) collatedStacks.get(j)).stackSize += 1;
                             found = true;
@@ -104,20 +64,20 @@ public class ItemUtil {
                     else if ((unCollatedStacks.get(i) instanceof OreStack) && (collatedStacks.get(j) instanceof OreStack)) {
                         OreStack unCollatedStack = (OreStack) unCollatedStacks.get(i);
                         OreStack collatedStack = (OreStack) collatedStacks.get(j);
-
+                        
                         if (OreStack.compareStacks(unCollatedStack, collatedStack)) {
                             ((OreStack) collatedStacks.get(j)).stackSize += 1;
                             found = true;
                         }
                     }
                 }
-
+                
                 if (!found) {
                     collatedStacks.add(unCollatedStacks.get(i));
                 }
             }
         }
-
+        
         return collatedStacks;
     }
 

--- a/ee3_common/com/pahimar/ee3/core/util/StringUtil.java
+++ b/ee3_common/com/pahimar/ee3/core/util/StringUtil.java
@@ -1,0 +1,16 @@
+package com.pahimar.ee3.core.util;
+
+import net.minecraft.item.ItemStack;
+
+
+public class StringUtil {
+
+    public static String toString(ItemStack itemStack) {
+        
+        StringBuilder stringBuilder = new StringBuilder();
+        
+        stringBuilder.append(String.format("itemID: %d, metaData: %d, stackSize: %d, itemName: %s, className: %s", itemStack.itemID, itemStack.getItemDamage(), itemStack.stackSize, itemStack.getItemName(), itemStack.getItem().getClass().toString()));
+        
+        return stringBuilder.toString();
+    }
+}

--- a/ee3_common/com/pahimar/ee3/emc/DynEMC.java
+++ b/ee3_common/com/pahimar/ee3/emc/DynEMC.java
@@ -6,34 +6,37 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.logging.Level;
 
+import net.minecraft.block.Block;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.IRecipe;
 
-import com.pahimar.ee3.core.util.ItemUtil;
 import com.pahimar.ee3.core.util.LogHelper;
 import com.pahimar.ee3.core.util.RecipeHelper;
+import com.pahimar.ee3.core.util.StringUtil;
+
 
 public class DynEMC {
-
+    
     private static final DynEMC dynEMC = new DynEMC();
     private static final ArrayList<Integer> idBlackList = new ArrayList<Integer>();
     private static final ArrayList<ItemStack> itemStackBlackList = new ArrayList<ItemStack>();
     private static final HashMap<List<Integer>, ItemStack> discoveredItems = new HashMap<List<Integer>, ItemStack>();
-
+    
+    
+    
     private DynEMC() {
-
+        
     }
-
+    
     public static DynEMC getInstance() {
-
+        
         return dynEMC;
     }
-
+    
     public void populateBlackList() {
-
         // List of ids to blacklist, more to clean up here
-        int[] blackints = { 7, 8, 9, 10, 11, 14, 15, 16, 21, 26, 34, 36, 43, 51, 52, 55, 56, 59, 60, 62, 63, 64, 68, 71, 73, 74, 75, 83, 90, 92, 93, 94, 95, 97, 104, 105, 115, 117, 118, 119, 120, 124, 125, 127, 129, 132, 137, 140, 141, 142, 144, 149, 150, 153 };
+        int[] blackints = {7,8,9,10,11,14,15,16,21,26,34,36,43,51,52,55,56,59,60,62,63,64,68,71,73,74,75,83,90,92,93,94,95,97,104,105,115,117,118,119,120,124,125,127,129,132,137,140,141,142,144,149,150,153};
 
         for (int i : blackints) {
             idBlackList.add(i);
@@ -41,21 +44,21 @@ public class DynEMC {
     }
 
     public void init() {
-
+        
         populateBlackList();
-
+        
         ArrayList<ItemStack> subItems = new ArrayList<ItemStack>();
-
+        
         for (int i = 0; i < Item.itemsList.length; i++) {
             if ((Item.itemsList[i] != null) && (!idBlackList.contains(i))) {
                 if (Item.itemsList[i].getHasSubtypes()) {
-
+                    
                     subItems.clear();
                     Item.itemsList[i].getSubItems(i, Item.itemsList[i].getCreativeTab(), subItems);
-
+                    
                     for (ItemStack itemStack : subItems) {
                         if (itemStack != null) {
-                            List<Integer> idMeta = Arrays.asList(itemStack.itemID, itemStack.getItemDamage());
+                            List idMeta = Arrays.asList(itemStack.itemID, itemStack.getItemDamage());
                             if (!discoveredItems.containsKey(idMeta)) {
                                 discoveredItems.put(idMeta, itemStack);
                             }
@@ -63,34 +66,34 @@ public class DynEMC {
                     }
                 }
                 else {
-
+                    
                     ItemStack itemStack = new ItemStack(Item.itemsList[i]);
-                    List<Integer> idMeta = Arrays.asList(itemStack.itemID, itemStack.getItemDamage());
-
+                    List idMeta = Arrays.asList(itemStack.itemID, itemStack.getItemDamage());
+                    
                     if (!discoveredItems.containsKey(idMeta)) {
                         discoveredItems.put(idMeta, itemStack);
                     }
                 }
             }
         }
-
+        
         for (ItemStack itemStack : itemStackBlackList) {
-            List<Integer> idMeta = Arrays.asList(itemStack.itemID, itemStack.getItemDamage());
-
+            List idMeta = Arrays.asList(itemStack.itemID, itemStack.getItemDamage());
+            
             if (discoveredItems.containsKey(idMeta)) {
                 discoveredItems.remove(idMeta);
             }
         }
-
+        
         for (ItemStack itemStack : discoveredItems.values()) {
             ArrayList<IRecipe> recipes = RecipeHelper.getReverseRecipes(itemStack);
             if (recipes.size() > 0) {
                 for (IRecipe recipe : recipes) {
-                    LogHelper.log(Level.INFO, ItemUtil.toString(itemStack) + " <-- " + RecipeHelper.getRecipeInputs(recipe));
+                    //LogHelper.log(Level.INFO, StringUtil.toString(itemStack) + " <-- " + RecipeHelper.getRecipeInputs(recipe));
                 }
             }
             else {
-                LogHelper.log(Level.INFO, ItemUtil.toString(itemStack));
+                LogHelper.log(Level.INFO, StringUtil.toString(itemStack));
             }
         }
     }

--- a/ee3_common/com/pahimar/ee3/item/ItemMiniumStone.java
+++ b/ee3_common/com/pahimar/ee3/item/ItemMiniumStone.java
@@ -93,7 +93,13 @@ public class ItemMiniumStone extends ItemEE
 
     @Override
     public void transmuteBlock(ItemStack itemStack, EntityPlayer player, World world, int x, int y, int z, int sideHit) {
-
+        int i;
+        for(i=0; i<TransmutationHelper.memories.size(); i++){
+        	if(ItemStack.areItemStacksEqual(TransmutationHelper.memories.get(i).current, TransmutationHelper.currentBlockStack)){
+        		break;
+        	}
+        }
+        TransmutationHelper.memories.set(i, new TransmutationHelper.TransmutationMemory());
         EquivalentExchange3.proxy.transmuteBlock(itemStack, player, world, x, y, z, sideHit);
     }
 
@@ -110,12 +116,19 @@ public class ItemMiniumStone extends ItemEE
         }
         else if (keyBinding.equals(ConfigurationSettings.KEYBINDING_TOGGLE)) {
             if (TransmutationHelper.targetBlockStack != null) {
+                int i;
+                for(i=0; i<TransmutationHelper.memories.size(); i++){
+                	if(ItemStack.areItemStacksEqual(TransmutationHelper.memories.get(i).current, TransmutationHelper.currentBlockStack)){
+                		break;
+                	}
+                }
                 if (!thePlayer.isSneaking()) {
                     TransmutationHelper.targetBlockStack = TransmutationHelper.getNextBlock(TransmutationHelper.targetBlockStack.itemID, TransmutationHelper.targetBlockStack.getItemDamage());
                 }
                 else {
                     TransmutationHelper.targetBlockStack = TransmutationHelper.getPreviousBlock(TransmutationHelper.targetBlockStack.itemID, TransmutationHelper.targetBlockStack.getItemDamage());
                 }
+                TransmutationHelper.memories.set(i, new TransmutationHelper.TransmutationMemory());
             }
         }
 

--- a/ee3_common/com/pahimar/ee3/item/ItemPhilosophersStone.java
+++ b/ee3_common/com/pahimar/ee3/item/ItemPhilosophersStone.java
@@ -100,6 +100,13 @@ public class ItemPhilosophersStone extends ItemEE
 
     @Override
     public void transmuteBlock(ItemStack itemStack, EntityPlayer player, World world, int x, int y, int z, int sideHit) {
+        int i;
+        for(i=0; i<TransmutationHelper.memories.size(); i++){
+        	if(ItemStack.areItemStacksEqual(TransmutationHelper.memories.get(i).current, TransmutationHelper.currentBlockStack)){
+        		break;
+        	}
+        }
+        TransmutationHelper.memories.set(i, new TransmutationHelper.TransmutationMemory());
 
         EquivalentExchange3.proxy.transmuteBlock(itemStack, player, world, x, y, z, sideHit);
     }
@@ -147,12 +154,19 @@ public class ItemPhilosophersStone extends ItemEE
         }
         else if (keyBinding.equals(ConfigurationSettings.KEYBINDING_TOGGLE)) {
             if (TransmutationHelper.targetBlockStack != null) {
+                int i;
+                for(i=0; i<TransmutationHelper.memories.size(); i++){
+                	if(ItemStack.areItemStacksEqual(TransmutationHelper.memories.get(i).current, TransmutationHelper.currentBlockStack)){
+                		break;
+                	}
+                }
                 if (!thePlayer.isSneaking()) {
                     TransmutationHelper.targetBlockStack = TransmutationHelper.getNextBlock(TransmutationHelper.targetBlockStack.itemID, TransmutationHelper.targetBlockStack.getItemDamage());
                 }
                 else {
                     TransmutationHelper.targetBlockStack = TransmutationHelper.getPreviousBlock(TransmutationHelper.targetBlockStack.itemID, TransmutationHelper.targetBlockStack.getItemDamage());
                 }
+                TransmutationHelper.memories.set(i, new TransmutationHelper.TransmutationMemory());
             }
         }
         else if (keyBinding.equals(ConfigurationSettings.KEYBINDING_CHARGE)) {


### PR DESCRIPTION
Adds timed world transmutation memory

World transmutation remembers which target selection you had for up to
three seconds after you select it or transmute to it. Each type of
highlighted block has its own timer. It is basically caching your
selections. The time (3 seconds) might need to be tweaked. Maybe a
config option?

Also folds in the mystcraft compatability bugfix.
