### PR TITLE
menium stone and Philosopher's Stone

### DIFF
--- a/ee3_common/com/pahimar/ee3/core/handlers/EquivalencyHandler.java
+++ b/ee3_common/com/pahimar/ee3/core/handlers/EquivalencyHandler.java
@@ -234,6 +234,7 @@ public class EquivalencyHandler {
         if (second == null)
             return false;
 
+        // if i transmt sand in to sand i crash
         if (getEquivalencyList(first.itemID, first.getItemDamage()) != null && getEquivalencyList(second.itemID, second.getItemDamage()) != null) {
             if (first.itemID == second.itemID && first.getItemDamage() == second.getItemDamage())
                 return true;


### PR DESCRIPTION
when i try and transmute blocks I can't i crasg f.x sand into sand
I get this

Caused by: java.lang.NullPointerException
    at net.minecraft.item.ItemStack.getItemDamage(ItemStack.java:268)
    at com.pahimar.ee3.core.handlers.EquivalencyHandler.areWorldEquivalent(EquivalencyHandler.java:237)
    at com.pahimar.ee3.core.handlers.WorldTransmutationHandler.onWorldTransmutationEvent(WorldTransmutationHandler.java:155)
    at net.minecraftforge.event.ASMEventHandler_12_WorldTransmutationHandler_onWorldTransmutationEvent_WorldTransmutationEvent.invoke(.dynamic)
    at net.minecraftforge.event.ASMEventHandler.invoke(ASMEventHandler.java:35)
    at net.minecraftforge.event.EventBus.post(EventBus.java:103)
    at com.pahimar.ee3.core.handlers.WorldTransmutationHandler.handleWorldTransmutation(WorldTransmutationHandler.java:107)
    at com.pahimar.ee3.network.packet.PacketRequestEvent.execute(PacketRequestEvent.java:83)
    at com.pahimar.ee3.network.PacketHandler.onPacketData(PacketHandler.java:41)
    at cpw.mods.fml.common.network.NetworkRegistry.handlePacket(NetworkRegistry.java:255)
    at cpw.mods.fml.common.network.NetworkRegistry.handleCustomPacket(NetworkRegistry.java:245)
    at cpw.mods.fml.common.network.FMLNetworkHandler.handlePacket250Packet(FMLNetworkHandler.java:84)
    at net.minecraft.network.NetServerHandler.handleCustomPayload(NetServerHandler.java:1098)
    at net.minecraft.network.packet.Packet250CustomPayload.processPacket(Packet250CustomPayload.java:70)
    at net.minecraft.network.MemoryConnection.processReadPackets(MemoryConnection.java:89)
    at net.minecraft.network.NetServerHandler.networkTick(NetServerHandler.java:134)
    at net.minecraft.network.NetworkListenThread.networkTick(NetworkListenThread.java:53)
    ... 6 more
