### PR TITLE
Fix for minium stone crash

### DIFF
--- a/ee3_common/com/pahimar/ee3/core/handlers/EquivalencyHandler.java
+++ b/ee3_common/com/pahimar/ee3/core/handlers/EquivalencyHandler.java
@@ -10,12 +10,12 @@ import com.pahimar.ee3.core.util.LogHelper;
 
 /**
  * Equivalent-Exchange-3
- * 
+ *
  * EquivalencyHandler
- * 
+ *
  * @author pahimar
  * @license Lesser GNU Public License v3 (http://www.gnu.org/licenses/lgpl.html)
- * 
+ *
  */
 public class EquivalencyHandler {
 
@@ -228,10 +228,10 @@ public class EquivalencyHandler {
     public boolean areWorldEquivalent(Object obj1, Object obj2) {
 
         ItemStack first = GeneralHelper.convertObjectToItemStack(obj1);
-        if (first == null)
+        if (first == null || first.getItem() == null)
             return false;
         ItemStack second = GeneralHelper.convertObjectToItemStack(obj2);
-        if (second == null)
+        if (second == null || second.getItem() == null)
             return false;
 
         if (getEquivalencyList(first.itemID, first.getItemDamage()) != null && getEquivalencyList(second.itemID, second.getItemDamage()) != null) {

--- a/ee3_common/com/pahimar/ee3/core/util/TransmutationHelper.java
+++ b/ee3_common/com/pahimar/ee3/core/util/TransmutationHelper.java
@@ -6,18 +6,19 @@ import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.Item;
 import net.minecraft.world.World;
 
 import com.pahimar.ee3.core.handlers.EquivalencyHandler;
 
 /**
  * Equivalent-Exchange-3
- * 
+ *
  * TransmutationHelper
- * 
+ *
  * @author pahimar
  * @license Lesser GNU Public License v3 (http://www.gnu.org/licenses/lgpl.html)
- * 
+ *
  */
 public class TransmutationHelper {
 
@@ -50,12 +51,12 @@ public class TransmutationHelper {
 
         Block currentBlock = Block.blocksList[id];
 
-        if (currentBlock != null) {
+        if (currentBlock != null && Item.itemsList[id] != null) {
             meta = currentBlock.damageDropped(meta);
-        
+
 
             currentBlockStack = new ItemStack(id, 1, meta);
-    
+
             if (previousBlockStack == null) {
                 previousBlockStack = currentBlockStack;
                 targetBlockStack = getNextBlock(currentBlockStack.itemID, currentBlockStack.getItemDamage());


### PR DESCRIPTION
Fixed a bug where mousing over or right clicking with the minium stone a block with no associated itemblock would crash the game.
