### PR TITLE
Fix forge-install fail on Linux

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -39,8 +39,8 @@
 			<arg value="/c" />
 			<arg value="${build.base_location}\forge\install.cmd" />
 		</exec>
-		<exec dir="${build.base_location}/forge/" executable="bash" osfamily="unix">
-			<arg line="reobfuscate_srg.sh" />
+		<exec dir="${build.base_location}/forge/" executable="bash" osfamily="unix" failonerror="true">
+			<arg line="install.sh" />
 		</exec>
 	</target>
 


### PR DESCRIPTION
Run appropriate command on Linux - install.sh instead of non-existing reobfuscate_srg.sh in Forge directory.
