### PR TITLE
Fix for crash when running with buggy mods.

### DIFF
--- a/common/com/pahimar/ee3/item/CustomWrappedStack.java
+++ b/common/com/pahimar/ee3/item/CustomWrappedStack.java
@@ -199,7 +199,7 @@ public class CustomWrappedStack implements Comparable<CustomWrappedStack> {
 
         StringBuilder stringBuilder = new StringBuilder();
 
-        if (itemStack != null) {
+        if (itemStack != null && Item.itemsList[itemStack.itemID] != null) {
             try {
                 stringBuilder.append(String.format("%sxitemStack[%s:%s:%s:%s]", stackSize, itemStack.itemID, itemStack.getItemDamage(), itemStack.getUnlocalizedName(), itemStack.getItem().getClass().getCanonicalName()));
             } catch (ArrayIndexOutOfBoundsException e) { 


### PR DESCRIPTION
When running EE3 with a mod that hasn't done its items/blocks properly (such as creating recipes with blocks that haven't been registered with the GameRegistry) the method as it was would crash the game.

Since there's a lot of poorly coded mods out there, a quick and harmless fix would help.
