### PR TITLE
Fix Alchemy Table Item render mis-rotated

### DIFF
--- a/common/com/pahimar/ee3/client/renderer/item/ItemAlchemyTableRenderer.java
+++ b/common/com/pahimar/ee3/client/renderer/item/ItemAlchemyTableRenderer.java
@@ -99,7 +99,7 @@ public class ItemAlchemyTableRenderer implements IItemRenderer {
         // Scale, Translate, Rotate
         GL11.glScalef(scale, scale, scale);
         GL11.glTranslatef(x, y, z);
-        GL11.glRotatef(-90F, 1F, 0, 0);
+        GL11.glRotatef(0F, 1F, 0, 0);
 
         // Bind texture
         FMLClientHandler.instance().getClient().renderEngine.bindTexture(Textures.MODEL_ALCHEMY_TABLE);


### PR DESCRIPTION
Simple fix for Alchemy Table item model being rotated when it did not need it.
