### PR TITLE
Fixed recipe value assignment when mods with custom IRecipe handler are added

### DIFF
--- a/common/com/pahimar/ee3/item/crafting/RecipesVanilla.java
+++ b/common/com/pahimar/ee3/item/crafting/RecipesVanilla.java
@@ -39,7 +39,11 @@ public class RecipesVanilla {
                 if (recipeOutput != null) {
 
                     ArrayList<CustomWrappedStack> recipeInputs = RecipeHelper.getRecipeInputs(recipe);
-                    vanillaRecipes.put(new CustomWrappedStack(recipeOutput), recipeInputs);
+                    
+                    if (!recipeInputs.isEmpty())
+                    {
+                        vanillaRecipes.put(new CustomWrappedStack(recipeOutput), recipeInputs);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Mods like IndustrialCraft 2 have their own IRecipe handlers, this made getRecipeInputs(IRecipe) return an empty ArrayList, which messed with the value assignment. This (easy) fix fixes that!
