### PR TITLE
Moved value assignment to onWorldLoad

### DIFF
--- a/common/com/pahimar/ee3/EquivalentExchange3.java
+++ b/common/com/pahimar/ee3/EquivalentExchange3.java
@@ -17,13 +17,13 @@ import com.pahimar.ee3.core.handler.ItemEventHandler;
 import com.pahimar.ee3.core.handler.ItemTooltipEventHandler;
 import com.pahimar.ee3.core.handler.PlayerDestroyItemHandler;
 import com.pahimar.ee3.core.handler.VersionCheckTickHandler;
+import com.pahimar.ee3.core.handler.WorldEventHandler;
 import com.pahimar.ee3.core.handler.WorldTransmutationHandler;
 import com.pahimar.ee3.core.handler.addon.AddonIMCHandler;
 import com.pahimar.ee3.core.helper.LogHelper;
 import com.pahimar.ee3.core.helper.VersionHelper;
 import com.pahimar.ee3.core.proxy.CommonProxy;
 import com.pahimar.ee3.creativetab.CreativeTabEE3;
-import com.pahimar.ee3.emc.EmcRegistry;
 import com.pahimar.ee3.item.ModItems;
 import com.pahimar.ee3.item.crafting.RecipesAlchemicalBagDyes;
 import com.pahimar.ee3.lib.Reference;
@@ -139,6 +139,8 @@ public class EquivalentExchange3 {
         MinecraftForge.EVENT_BUS.register(new WorldTransmutationHandler());
 
         MinecraftForge.EVENT_BUS.register(new ItemTooltipEventHandler());
+        
+        MinecraftForge.EVENT_BUS.register(new WorldEventHandler());
 
         GameRegistry.registerCraftingHandler(new CraftingHandler());
 
@@ -161,7 +163,6 @@ public class EquivalentExchange3 {
     @EventHandler
     public void modsLoaded(FMLPostInitializationEvent event) {
         
-        EmcRegistry.lazyInit();
     }
 
     @EventHandler

--- a/common/com/pahimar/ee3/core/handler/WorldEventHandler.java
+++ b/common/com/pahimar/ee3/core/handler/WorldEventHandler.java
@@ -1,0 +1,15 @@
+package com.pahimar.ee3.core.handler;
+
+import com.pahimar.ee3.emc.EmcRegistry;
+
+import net.minecraftforge.event.ForgeSubscribe;
+import net.minecraftforge.event.world.WorldEvent.Load;
+
+public class WorldEventHandler {
+    
+    @ForgeSubscribe
+    public void onWorldLoaded(Load event){
+        
+        EmcRegistry.lazyInit();
+    }
+}

--- a/common/com/pahimar/ee3/item/crafting/RecipesVanilla.java
+++ b/common/com/pahimar/ee3/item/crafting/RecipesVanilla.java
@@ -40,8 +40,8 @@ public class RecipesVanilla {
 
                     ArrayList<CustomWrappedStack> recipeInputs = RecipeHelper.getRecipeInputs(recipe);
                     
-                    if (!recipeInputs.isEmpty())
-                    {
+                    if (!recipeInputs.isEmpty()) {
+                        
                         vanillaRecipes.put(new CustomWrappedStack(recipeOutput), recipeInputs);
                     }
                 }


### PR DESCRIPTION
Some mods register their recipes in postInit and will not be used in value assignment. Moving value assignment to when the world loads will make sure every recipe get's added. (also formatted previous PR)
