### PR TITLE
Fixed constant merge conflicts in build.properties

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-build.properties text
+build.properties text merge=ours


### PR DESCRIPTION
Due to `build.number` and to some extent `mod_version` being situated in `build.properties`, whenever `build.properties` changes on both pahimar's and the local end, a merge conflict results.  This fixes that by making Git always keep the local version whenever a merge conflict would have occurred.  This does make for some manual updating of the file, but I think it's better than having to discard your changes in the file over and over again.
(http://git-scm.com/book/ch7-2.html#Merge-Strategies)
