### PR TITLE
Prevented crash when right-clicking the aludel

### DIFF
--- a/src/main/java/com/pahimar/ee3/block/BlockAludelBase.java
+++ b/src/main/java/com/pahimar/ee3/block/BlockAludelBase.java
@@ -88,7 +88,7 @@ public class BlockAludelBase extends BlockEE implements ITileEntityProvider
                 }
                 else if (world.getBlockTileEntity(x, y, z) instanceof TileAludel && ModBlocks.glassBell.canPlaceBlockAt(world, x, y + 1, z) && faceHit == ForgeDirection.UP.ordinal())
                 {
-                    if (player.getHeldItem().itemID == ModBlocks.glassBell.blockID)
+                    if (player.getHeldItem() != null && player.getHeldItem().itemID == ModBlocks.glassBell.blockID)
                     {
                         player.getHeldItem().getItem().onItemUse(player.getHeldItem(), player, world, x, y, z, faceHit, par7, par8, par9);
                     }


### PR DESCRIPTION
Checks if the stack is null before attempting to get the item ID
