### PR TITLE
Change event priority for tooltip event

### DIFF
--- a/src/main/java/com/pahimar/ee3/client/handler/ItemTooltipEventHandler.java
+++ b/src/main/java/com/pahimar/ee3/client/handler/ItemTooltipEventHandler.java
@@ -5,6 +5,7 @@ import com.pahimar.ee3.emc.EmcRegistry;
 import com.pahimar.ee3.emc.EmcValue;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import net.minecraftforge.event.EventPriority;
 import net.minecraftforge.event.ForgeSubscribe;
 import net.minecraftforge.event.entity.player.ItemTooltipEvent;
 import org.lwjgl.input.Keyboard;
@@ -24,7 +25,7 @@ public class ItemTooltipEventHandler
     private static boolean debug = true;
     private static DecimalFormat emcDecimalFormat = new DecimalFormat("#.###");
 
-    @ForgeSubscribe
+    @ForgeSubscribe(priority = EventPriority.LOWEST)
     public void handleItemTooltipEvent(ItemTooltipEvent event)
     {
         if (Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) || Keyboard.isKeyDown(Keyboard.KEY_RSHIFT))


### PR DESCRIPTION
Makes sure the event is called after (as much as possible of course) all other tool tip events, so that the EMC value is always the last thing on the item tool tip and avoids it ending up in between the tooltips added by two different mods.
