### PR TITLE
Fix for calcinator light level update

### DIFF
--- a/src/main/java/com/pahimar/ee3/tileentity/TileCalcinator.java
+++ b/src/main/java/com/pahimar/ee3/tileentity/TileCalcinator.java
@@ -126,6 +126,7 @@ public class TileCalcinator extends TileEE implements IInventory
         if (eventId == 1)
         {
             this.state = (byte) eventData;
+            this.worldObj.updateAllLightTypes(this.xCoord, this.yCoord, this.zCoord);
             return true;
         }
         else if (eventId == 2)


### PR DESCRIPTION
Force a light level update every time the tile entity state is changed.
Could also be done by sending an eventId == 6 and make that update the light level, but I think this way is simpler and it makes sure the light level is updated only after the state is changed

Fixes #569
