### PR TITLE
Better formatting for EMC value shown on tooltips

### DIFF
--- a/src/main/java/com/pahimar/ee3/client/handler/ItemTooltipEventHandler.java
+++ b/src/main/java/com/pahimar/ee3/client/handler/ItemTooltipEventHandler.java
@@ -1,16 +1,20 @@
 package com.pahimar.ee3.client.handler;
 
-import com.pahimar.ee3.api.WrappedStack;
-import com.pahimar.ee3.emc.EmcRegistry;
-import com.pahimar.ee3.emc.EmcValue;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+
 import net.minecraftforge.event.EventPriority;
 import net.minecraftforge.event.ForgeSubscribe;
 import net.minecraftforge.event.entity.player.ItemTooltipEvent;
+
 import org.lwjgl.input.Keyboard;
 
-import java.text.DecimalFormat;
+import com.pahimar.ee3.api.WrappedStack;
+import com.pahimar.ee3.emc.EmcRegistry;
+import com.pahimar.ee3.emc.EmcValue;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 
 /**
  * Equivalent-Exchange-3
@@ -23,6 +27,14 @@ import java.text.DecimalFormat;
 public class ItemTooltipEventHandler
 {
     private static DecimalFormat emcDecimalFormat = new DecimalFormat("#.###");
+    private static DecimalFormatSymbols emcDecimalFormatSymbols = new DecimalFormatSymbols();
+    static {
+    	emcDecimalFormat.setGroupingSize(3);
+    	emcDecimalFormat.setGroupingUsed(true);
+    	emcDecimalFormatSymbols.setDecimalSeparator('.');
+    	emcDecimalFormatSymbols.setGroupingSeparator(',');
+    	emcDecimalFormat.setDecimalFormatSymbols(emcDecimalFormatSymbols);
+    }
 
     @ForgeSubscribe(priority = EventPriority.LOWEST)
     public void handleItemTooltipEvent(ItemTooltipEvent event)


### PR DESCRIPTION
Large EMC values are hard to read due to the lack of commas.
Old: 123456789.312
New: 123,456,789.312

The same could also be achieved in a much simpler way buy doing simply this:

event.toolTip.add("EMC: " + String.format("%,.3f", stack.getStackSize() \* emcValue.getValue())):

But that would force the decimals to always be shown:
Old: 1
New: 1.000
