### PR TITLE
Updated .gitignore to properly ignore all non-EE3 files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,15 @@
 ## gradle
 /.gradle
 /build
+/gradle
+/gradlew
+/gradlew.bat
 
 ## ForgeGradle
 /run
 
 ## eclipse
+/eclipse
 /.settings
 /.metadata
 /.classpath
@@ -16,4 +20,6 @@
 /out
 /.idea
 /*.iml
+/*.ipr
+/*.iws
 /atlassian-ide-plugin.xml


### PR DESCRIPTION
Updated .gitignore. Added support for the ForgeGradle wrapper and fixed IntelliJ support.
