### PR TITLE
Fixed OreStack EMC values not being looked up properly

### DIFF
--- a/src/main/java/com/pahimar/ee3/emc/EmcRegistry.java
+++ b/src/main/java/com/pahimar/ee3/emc/EmcRegistry.java
@@ -314,6 +314,17 @@ public class EmcRegistry
                             }
                         }
                     }
+                    else if (stack.getWrappedStack() instanceof OreStack)
+                    {
+                        OreStack oreStack = (OreStack)stack.getWrappedStack();
+                        for (ItemStack oreItemStack : OreDictionary.getOres(oreStack.oreName))
+                        {
+                            if (emcRegistry.stackMappings.containsKey(new WrappedStack(oreItemStack)))
+                            {
+                                return true;
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -397,6 +408,17 @@ public class EmcRegistry
                         }
 
                         return lowestValue;
+                    }
+                }
+                else if (stack.getWrappedStack() instanceof OreStack)
+                {
+                    OreStack oreStack = (OreStack)stack.getWrappedStack();
+                    for (ItemStack oreItemStack : OreDictionary.getOres(oreStack.oreName))
+                    {
+                        if (emcRegistry.stackMappings.containsKey(new WrappedStack(oreItemStack)))
+                        {
+                            return emcRegistry.stackMappings.get(new WrappedStack(oreItemStack));
+                        }
                     }
                 }
             }

--- a/src/main/java/com/pahimar/ee3/helper/RecipeHelper.java
+++ b/src/main/java/com/pahimar/ee3/helper/RecipeHelper.java
@@ -98,7 +98,7 @@ public class RecipeHelper
 
                     if (oreStack.getWrappedStack() instanceof OreStack)
                     {
-                        recipeInputs.add(new WrappedStack(shapedOreRecipe.getInput()[i]));
+                        recipeInputs.add(oreStack);
                     }
                 }
                 else if (shapedOreRecipe.getInput()[i] instanceof ItemStack)


### PR DESCRIPTION
Getting the EMC valueof an OreStack just checked if the OreStack was in the recipeMappings and did not check if an ItemStack of the Ore was in the recipeMappings. This PR fixes this and because of that it also fixes https://github.com/pahimar/Equivalent-Exchange-3/issues/598.
