### PR TITLE
Tidied up the log and debug methods in LogHelper

### DIFF
--- a/src/main/java/com/pahimar/ee3/helper/LogHelper.java
+++ b/src/main/java/com/pahimar/ee3/helper/LogHelper.java
@@ -25,14 +25,7 @@ public class LogHelper
 
     public static void log(Level logLevel, Object object)
     {
-        if (object != null)
-        {
-            eeLogger.log(logLevel, object.toString());
-        }
-        else
-        {
-            eeLogger.log(logLevel, "null");
-        }
+        eeLogger.log(logLevel, String.valueOf(object));
     }
 
     public static void severe(Object object)
@@ -42,14 +35,7 @@ public class LogHelper
 
     public static void debug(Object object)
     {
-        if (object != null)
-        {
-            log(Level.INFO, String.format("[DEBUG] %s", object.toString()));
-        }
-        else
-        {
-            log(Level.INFO, "[DEBUG] null");
-        }
+        log(Level.INFO, String.format("[DEBUG] %s", String.valueOf(object.toString)));
     }
 
     public static void warning(Object object)


### PR DESCRIPTION
Changed the manual null check and String conversion in LogHelper to the static String.valueOf() method, which automatically performs a null check and handles it appropriately. See [String.valueOf(Object)](http://docs.oracle.com/javase/7/docs/api/java/lang/String.html#valueOf(java.lang.Object\)).
