### PR TITLE
Fixes Aludel consuming wrong amount of items

### DIFF
--- a/src/main/java/com/pahimar/ee3/recipe/RecipesAludel.java
+++ b/src/main/java/com/pahimar/ee3/recipe/RecipesAludel.java
@@ -96,13 +96,13 @@ public class RecipesAludel
         return null;
     }
 
-    public ItemStack[] getRecipeInputs(ItemStack itemStack)
+    public RecipeAludel getRecipe(ItemStack recipeInputStack, ItemStack recipeInputDust)
     {
         for (RecipeAludel recipeAludel : aludelRecipes)
         {
-            if (ItemHelper.equals(recipeAludel.getRecipeOutput(), itemStack))
+            if (recipeAludel.matches(recipeInputStack, recipeInputDust))
             {
-                return recipeAludel.getRecipeInputs();
+                return recipeAludel;
             }
         }
 

--- a/src/main/java/com/pahimar/ee3/tileentity/TileAludel.java
+++ b/src/main/java/com/pahimar/ee3/tileentity/TileAludel.java
@@ -1,6 +1,7 @@
 package com.pahimar.ee3.tileentity;
 
 import com.pahimar.ee3.helper.ItemHelper;
+import com.pahimar.ee3.item.crafting.RecipeAludel;
 import com.pahimar.ee3.lib.Strings;
 import com.pahimar.ee3.network.PacketTypeHandler;
 import com.pahimar.ee3.network.packet.PacketTileWithItemUpdate;
@@ -319,20 +320,19 @@ public class TileAludel extends TileEE implements IInventory
     {
         if (this.canInfuse())
         {
-            ItemStack infusedItemStack = RecipesAludel.getInstance().getResult(inventory[INPUT_INVENTORY_INDEX], inventory[DUST_INVENTORY_INDEX]);
-            ItemStack[] inputPair = RecipesAludel.getInstance().getRecipeInputs(infusedItemStack);
+            RecipeAludel recipe = RecipesAludel.getInstance().getRecipe(inventory[INPUT_INVENTORY_INDEX], inventory[DUST_INVENTORY_INDEX]);
 
             if (this.inventory[OUTPUT_INVENTORY_INDEX] == null)
             {
-                this.inventory[OUTPUT_INVENTORY_INDEX] = infusedItemStack.copy();
+                this.inventory[OUTPUT_INVENTORY_INDEX] = recipe.getRecipeOutput().copy();
             }
-            else if (this.inventory[OUTPUT_INVENTORY_INDEX].isItemEqual(infusedItemStack))
+            else if (this.inventory[OUTPUT_INVENTORY_INDEX].isItemEqual(recipe.getRecipeOutput()))
             {
-                inventory[OUTPUT_INVENTORY_INDEX].stackSize += infusedItemStack.stackSize;
+                inventory[OUTPUT_INVENTORY_INDEX].stackSize += recipe.getRecipeOutput().stackSize;
             }
 
-            decrStackSize(INPUT_INVENTORY_INDEX, inputPair[0].stackSize);
-            decrStackSize(DUST_INVENTORY_INDEX, inputPair[1].stackSize);
+            decrStackSize(INPUT_INVENTORY_INDEX, recipe.getRecipeInputs()[0].stackSize);
+            decrStackSize(DUST_INVENTORY_INDEX, recipe.getRecipeInputs()[1].stackSize);
         }
     }
 


### PR DESCRIPTION
Replaced getRecipeInputs with getRecipe, because getRecipeInputs will not always return the right inputs when two or more recipes create the same ItemStack. This fixes a bug where the Aludel uses the wrong amount of items to infuse items(example: mobius fuel -> aeternalis fuel uses 56 minium dust instead of 14).
