### PR TITLE
Fixes #626

### DIFF
--- a/src/main/java/com/pahimar/ee3/tileentity/TileCalcinator.java
+++ b/src/main/java/com/pahimar/ee3/tileentity/TileCalcinator.java
@@ -382,7 +382,9 @@ public class TileCalcinator extends TileEE implements IInventory
             {
                 this.inventory[OUTPUT_LEFT_INVENTORY_INDEX] = alchemicalDustStack.copy();
             }
-            else if (this.inventory[OUTPUT_LEFT_INVENTORY_INDEX].isItemEqual(alchemicalDustStack))
+            else if (this.inventory[OUTPUT_LEFT_INVENTORY_INDEX].isItemEqual(alchemicalDustStack)
+                    && this.inventory[OUTPUT_LEFT_INVENTORY_INDEX].stackSize < getInventoryStackLimit()
+                    && this.inventory[OUTPUT_LEFT_INVENTORY_INDEX].stackSize < this.inventory[OUTPUT_LEFT_INVENTORY_INDEX].getMaxStackSize())
             {
                 inventory[OUTPUT_LEFT_INVENTORY_INDEX].stackSize += alchemicalDustStack.stackSize;
             }
@@ -390,7 +392,9 @@ public class TileCalcinator extends TileEE implements IInventory
             {
                 this.inventory[OUTPUT_RIGHT_INVENTORY_INDEX] = alchemicalDustStack.copy();
             }
-            else if (this.inventory[OUTPUT_RIGHT_INVENTORY_INDEX].isItemEqual(alchemicalDustStack))
+            else if (this.inventory[OUTPUT_RIGHT_INVENTORY_INDEX].isItemEqual(alchemicalDustStack)
+                    && this.inventory[OUTPUT_RIGHT_INVENTORY_INDEX].stackSize < getInventoryStackLimit()
+                    && this.inventory[OUTPUT_RIGHT_INVENTORY_INDEX].stackSize < this.inventory[OUTPUT_RIGHT_INVENTORY_INDEX].getMaxStackSize())
             {
                 inventory[OUTPUT_RIGHT_INVENTORY_INDEX].stackSize += alchemicalDustStack.stackSize;
             }


### PR DESCRIPTION
Calcinator will now not try to ouput to the outputslots if they cannot hold more items.
