### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Gradle is used to execute the various build tasks when compiling EE3.
 Git is used to clone EE3 and update your local copy.
 
 1. Download and install Git [here](http://git-scm.com/download/).
-2. *Optional*: Download and install a Git GUI client, such as Github for Windows/Mac, SmartGitHg, TortoiseGit, etc.  A nice list is available [here](http://git-scm.com/downloads/guis).
+	* *Optional*: Download and install a Git GUI client, such as Github for Windows/Mac, SmartGitHg, TortoiseGit, etc.  A nice list is available [here](http://git-scm.com/downloads/guis).
 
 ####Setup EE3
 This section assumes that you're using the command-line version of Git.


### PR DESCRIPTION
Bumped Java and Gradle versions.
Notified users about the `null` part in the jar name.
Clarified a bit about what constitutes a valid issue.

@pahimar, would you mind putting an [embeddable build status](https://wiki.jenkins-ci.org/display/JENKINS/Embeddable+Build+Status+Plugin) in the README somwhere?

And also, if you think the link to "pahimar's Twitter" should only catch "Twitter", or "Twitter" should be lowercase, let me know ;).

EDIT:  Should `setupDevWorkspace` be `setupCIWorkspace`?  BC's README (updated by abrar) currently lists `setupCIWorkspace` as the recommended setup.
