### PR TITLE
Create ru_RU.lang

### DIFF
--- a/src/main/resources/assets/ee3/lang/ru_RU.lang
+++ b/src/main/resources/assets/ee3/lang/ru_RU.lang
@@ -35,8 +35,8 @@ tile.ee3:infusedWood.name=Настоянная древесина
 tile.ee3:infusedPlanks.name=Настоянные доски
 
 # Интерфейс
-container.ee3:alchemicalBag=Алхемический мешок
-container.ee3:alchemicalChest=Алхемический сундук
+container.ee3:alchemicalBag=Алхимический мешок
+container.ee3:alchemicalChest=Алхимический сундук
 container.ee3:aludel=Алудель
 container.ee3:calcinator=Кальцинатор
 container.ee3:glassBell=Стеклянный алембик


### PR DESCRIPTION
Mod is fully translated into Russian, but Alchemical Chest has no tooltip localization.

---

Мод полностью переведен на русский, но Алхимический сундук не имеет поля для перевода подсказки.
