### PR TITLE
Adding a link to ee3.pahimar.com instead of linking to minecraftforum.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 ##Welcome to Equivalent Exchange 3!
-
 **SEE ALL THE DOWNLOADS HERE**: [EE3 Downloads, Latest 0.2.234 for MC 1.7.10](http://ee3.pahimar.com/)
 
 [Minecraft Forums page](http://www.minecraftforum.net/topic/1540010-equivalent-exchange-3)


### PR DESCRIPTION
Changing the link to downloads so it doesn't have to be updated every time there's a new official release
