### PR TITLE
Added support for the Minecraft mod (http://bit.ly/1qBklHF)

### DIFF
--- a/src/main/java/com/pahimar/ee3/EquivalentExchange3.java
+++ b/src/main/java/com/pahimar/ee3/EquivalentExchange3.java
@@ -90,6 +90,9 @@ public class EquivalentExchange3
 
         CraftingHandler.init();
         Recipes.init();
+        
+     // Initialize VersionChecker
+        FMLInterModComms.sendRuntimeMessage(Reference.MOD_ID, "VersionChecker", "addVersionCheck", Reference.VERSION_CHECKER_REMOTE_URL);
 
         // Register our fuels
         GameRegistry.registerFuelHandler(new FuelHandler());

--- a/src/main/java/com/pahimar/ee3/reference/Reference.java
+++ b/src/main/java/com/pahimar/ee3/reference/Reference.java
@@ -8,4 +8,5 @@ public class Reference
     public static final String VERSION = "@VERSION@";
     public static final String SERVER_PROXY_CLASS = "com.pahimar.ee3.proxy.ServerProxy";
     public static final String CLIENT_PROXY_CLASS = "com.pahimar.ee3.proxy.ClientProxy";
+    public static final String VERSION_CHECKER_REMOTE_URL = "";
 }

--- a/versionChecker.json
+++ b/versionChecker.json
@@ -1,0 +1,15 @@
+{
+	"versionList": [
+		{
+			"mcVersion":"Minecraft 1.7.10",
+			"modVersion":"1.0.5",
+			"changeLog": [
+				"",
+				""
+			],
+			"updateURL":"http://www.pahimar.com/",
+			"isDirectLink":"false",
+			"newFileName":""
+		}
+	]
+}


### PR DESCRIPTION
This adds support for the minecraft mod VersionChecker, this mod requires you to host a file on github (as you already do with your current version setup) and link it in the Reference file.  Then all you need to do to update the mod is change the "ModVersion" in VersionChecker.json and it will automatically offer an update to all users that have the mod installed.
The tread for the mod is -> http://www.minecraftforum.net/forums/mapping-and-modding/minecraft-mods/2091981-version-checker-auto-update-mods-and-clean