### PR TITLE
Fixes #705

### DIFF
--- a/src/main/java/com/pahimar/ee3/exchange/WrappedStack.java
+++ b/src/main/java/com/pahimar/ee3/exchange/WrappedStack.java
@@ -106,11 +106,18 @@ public class WrappedStack implements Comparable<WrappedStack>
 
         if (object instanceof ItemStack)
         {
-            ItemStack itemStack = ((ItemStack) object).copy();
-
-            stackSize = itemStack.stackSize;
-            itemStack.stackSize = 1;
-            wrappedStack = itemStack;
+            if (((ItemStack) object).getItem() != null)
+            {
+                ItemStack itemStack = ((ItemStack) object).copy();
+                stackSize = itemStack.stackSize;
+                itemStack.stackSize = 1;
+                wrappedStack = itemStack;
+            }
+            else
+            {
+                stackSize = -1;
+                wrappedStack = null;
+            }
         }
         else if (object instanceof OreStack)
         {
@@ -259,9 +266,16 @@ public class WrappedStack implements Comparable<WrappedStack>
         {
             return true;
         }
-        else if (object instanceof Item || object instanceof Block || object instanceof ItemStack)
+        else if (object instanceof Item || object instanceof Block)
         {
             return true;
+        }
+        else if (object instanceof ItemStack)
+        {
+            if (((ItemStack)object).getItem() != null)
+            {
+                return true;
+            }
         }
         else if (object instanceof OreStack)
         {


### PR DESCRIPTION
This fixes the crash reported in #705. Adds a null check in both the constructor and the canBeWrapped method. Nothing fancy.
