### PR TITLE
Fixes issues from #714

### DIFF
--- a/src/main/java/com/pahimar/ee3/handler/ItemEventHandler.java
+++ b/src/main/java/com/pahimar/ee3/handler/ItemEventHandler.java
@@ -1,5 +1,6 @@
 package com.pahimar.ee3.handler;
 
+import com.pahimar.ee3.inventory.ContainerAlchemicalBag;
 import com.pahimar.ee3.util.NBTHelper;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.PlayerEvent;
@@ -14,6 +15,17 @@ public class ItemEventHandler
     public void onItemTossEvent(ItemTossEvent itemTossEvent)
     {
         NBTHelper.clearStatefulNBTTags(itemTossEvent.entityItem.getEntityItem());
+
+        //Close the Alchemical Bag GUI when the Alchemical bag is tossed
+        if (itemTossEvent.player.openContainer instanceof ContainerAlchemicalBag)
+        {
+            if (((ContainerAlchemicalBag)itemTossEvent.player.openContainer).isStackParent(itemTossEvent.entityItem.getEntityItem()))
+            {
+                //We have to remove the itemstack we are throwing from the inventory now to prevent a loop (will also happen after this event has been fired)
+                itemTossEvent.player.inventory.setItemStack(null);
+                itemTossEvent.player.closeScreen();
+            }
+        }
     }
 
     @SubscribeEvent

--- a/src/main/java/com/pahimar/ee3/inventory/ContainerAlchemicalBag.java
+++ b/src/main/java/com/pahimar/ee3/inventory/ContainerAlchemicalBag.java
@@ -8,6 +8,8 @@ import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 
+import java.util.UUID;
+
 public class ContainerAlchemicalBag extends ContainerEE
 {
     // Small Bag
@@ -187,5 +189,15 @@ public class ContainerAlchemicalBag extends ContainerEE
     public void saveInventory(EntityPlayer entityPlayer)
     {
         inventoryAlchemicalBag.onGuiSaved(entityPlayer);
+    }
+
+    public boolean isStackParent(ItemStack stack)
+    {
+        if (NBTHelper.hasUUID(stack))
+        {
+            UUID stackUUID = new UUID(stack.getTagCompound().getLong(Names.NBT.UUID_MOST_SIG), stack.getTagCompound().getLong(Names.NBT.UUID_LEAST_SIG));
+            return inventoryAlchemicalBag.matchesUUID(stackUUID);
+        }
+        return false;
     }
 }

--- a/src/main/java/com/pahimar/ee3/inventory/SlotAlchemicalBag.java
+++ b/src/main/java/com/pahimar/ee3/inventory/SlotAlchemicalBag.java
@@ -1,6 +1,7 @@
 package com.pahimar.ee3.inventory;
 
 import com.pahimar.ee3.item.ItemAlchemicalBag;
+import cpw.mods.fml.common.FMLCommonHandler;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.Slot;
@@ -19,10 +20,15 @@ public class SlotAlchemicalBag extends Slot
     }
 
     @Override
-    public void onSlotChange(ItemStack itemStack1, ItemStack itemStack2)
+    public void onSlotChanged()
     {
-        super.onSlotChange(itemStack1, itemStack2);
-        containerAlchemicalBag.saveInventory(entityPlayer);
+        super.onSlotChanged();
+
+        //Only save on server side to prevent a huge amount of client-side saving when the bag is opened
+        if (FMLCommonHandler.instance().getEffectiveSide().isServer())
+        {
+            containerAlchemicalBag.saveInventory(entityPlayer);
+        }
     }
 
     /**


### PR DESCRIPTION
Slots were not triggering a save when items are added/removed from the slot. To fix this I changed saving from the Slot#onSlotChange() to Slot#onSlotChanged(), this bug was probably introduced in the port to 1.7.

When the player removes the Alchemical Bag from their inventory when the Alchemical Bag GUI was open (by tossing it on the ground) the GUI did not close. This has been fixed by hooking into the onItemTossEvent and closing the GUI when the 'parent' of the container was tossed.