### PR TITLE
Minor fixes from the list of TODOs and *sudo* fix for error in latest commit

### DIFF
--- a/src/main/java/com/pahimar/ee3/client/renderer/tileentity/TileEntityRendererGlassBell.java
+++ b/src/main/java/com/pahimar/ee3/client/renderer/tileentity/TileEntityRendererGlassBell.java
@@ -5,6 +5,7 @@ import com.pahimar.ee3.reference.Textures;
 import com.pahimar.ee3.tileentity.TileEntityGlassBell;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.entity.RenderItem;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
@@ -67,19 +68,21 @@ public class TileEntityRendererGlassBell extends TileEntitySpecialRenderer
 
             if (tileEntityGlassBell.outputItemStack != null)
             {
-                // TODO Stop the ghost item rendering in the event that the client's game is paused
-                float scaleFactor = getGhostItemScaleFactor(tileEntityGlassBell.outputItemStack);
-                float rotationAngle = (float) (720.0 * (System.currentTimeMillis() & 0x3FFFL) / 0x3FFFL);
+            	if (Minecraft.getMinecraft().currentScreen == null && Minecraft.getMinecraft().inGameHasFocus)
+            	{
+            		float scaleFactor = getGhostItemScaleFactor(tileEntityGlassBell.outputItemStack);
+                    float rotationAngle = (float) (720.0 * (System.currentTimeMillis() & 0x3FFFL) / 0x3FFFL);
 
-                EntityItem ghostEntityItem = new EntityItem(tileEntityGlassBell.getWorldObj());
-                ghostEntityItem.hoverStart = 0.0F;
-                ghostEntityItem.setEntityItemStack(tileEntityGlassBell.outputItemStack);
+                    EntityItem ghostEntityItem = new EntityItem(tileEntityGlassBell.getWorldObj());
+                    ghostEntityItem.hoverStart = 0.0F;
+                    ghostEntityItem.setEntityItemStack(tileEntityGlassBell.outputItemStack);
 
-                translateGhostItemByOrientation(ghostEntityItem.getEntityItem(), x, y, z, tileEntityGlassBell.getOrientation());
-                GL11.glScalef(scaleFactor, scaleFactor, scaleFactor);
-                GL11.glRotatef(rotationAngle, 0.0F, 1.0F, 0.0F);
+                    translateGhostItemByOrientation(ghostEntityItem.getEntityItem(), x, y, z, tileEntityGlassBell.getOrientation());
+                    GL11.glScalef(scaleFactor, scaleFactor, scaleFactor);
+                    GL11.glRotatef(rotationAngle, 0.0F, 1.0F, 0.0F);
 
-                customRenderItem.doRender(ghostEntityItem, 0, 0, 0, 0, 0);
+                    customRenderItem.doRender(ghostEntityItem, 0, 0, 0, 0, 0);
+            	}
             }
 
             GL11.glPopMatrix();

--- a/src/main/java/com/pahimar/ee3/handler/ConfigurationHandler.java
+++ b/src/main/java/com/pahimar/ee3/handler/ConfigurationHandler.java
@@ -32,6 +32,7 @@ public class ConfigurationHandler
         Settings.Transmutation.maxKnowledgeTier = configuration.getInt(Messages.Configuration.TRANSMUTATION_KNOWLEDGE_MAX_TIER, Messages.Configuration.CATEGORY_TRANSMUTATION, 0, 0, Short.MAX_VALUE, StatCollector.translateToLocal(Messages.Configuration.TRANSMUTATION_KNOWLEDGE_MAX_TIER_COMMENT), Messages.Configuration.TRANSMUTATION_KNOWLEDGE_MAX_TIER_LABEL);
         Settings.Transmutation.useTemplateFile = configuration.getBoolean(Messages.Configuration.TRANSMUTATION_KNOWLEDGE_TEMPLATE, Messages.Configuration.CATEGORY_TRANSMUTATION, true, StatCollector.translateToLocal(Messages.Configuration.TRANSMUTATION_KNOWLEDGE_TEMPLATE_COMMENT), Messages.Configuration.TRANSMUTATION_KNOWLEDGE_TEMPLATE_LABEL);
         Settings.Sounds.soundMode = ConfigurationHelper.getString(configuration, Messages.Configuration.SOUND_MODE, Configuration.CATEGORY_GENERAL, "All", StatCollector.translateToLocal(Messages.Configuration.SOUND_MODE_COMMENT), new String[]{"All", "Self", "None"}, Messages.Configuration.SOUND_MODE_LABEL);
+        Settings.Tools.miniumMaxDamage = configuration.getInt(Messages.Configuration.TOOL_MINIUM_STONE_MAX, Configuration.CATEGORY_GENERAL, 1000, 1, 9999, StatCollector.translateToLocal(Messages.Configuration.TOOL_MINIUM_STONE_MAX_COMMENT));
 
         if (configuration.hasChanged())
         {

--- a/src/main/java/com/pahimar/ee3/inventory/InventoryAlchemicalTome.java
+++ b/src/main/java/com/pahimar/ee3/inventory/InventoryAlchemicalTome.java
@@ -5,6 +5,7 @@ import com.pahimar.ee3.skill.PlayerKnowledge;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
 
 public class InventoryAlchemicalTome implements IInventory
 {
@@ -14,8 +15,7 @@ public class InventoryAlchemicalTome implements IInventory
 
     public InventoryAlchemicalTome(ItemStack itemStack)
     {
-        // TODO Handle case where there the NBTTagCompound of the ItemStack is invalid/uninitialized
-        this(PlayerKnowledge.readPlayerKnowledgeFromNBT(itemStack.getTagCompound()));
+    	this(itemStack.hasTagCompound() ? PlayerKnowledge.readPlayerKnowledgeFromNBT(itemStack.getTagCompound()) : PlayerKnowledge.readPlayerKnowledgeFromNBT(new NBTTagCompound()));
     }
 
     public InventoryAlchemicalTome(PlayerKnowledge playerKnowledge)

--- a/src/main/java/com/pahimar/ee3/item/ItemMiniumStone.java
+++ b/src/main/java/com/pahimar/ee3/item/ItemMiniumStone.java
@@ -2,6 +2,7 @@ package com.pahimar.ee3.item;
 
 import com.pahimar.ee3.reference.Key;
 import com.pahimar.ee3.reference.Names;
+import com.pahimar.ee3.reference.Settings;
 import com.pahimar.ee3.util.IKeyBound;
 import com.pahimar.ee3.util.LogHelper;
 import com.pahimar.ee3.util.NBTHelper;
@@ -16,7 +17,7 @@ public class ItemMiniumStone extends ItemEE implements IKeyBound
     {
         super();
         this.setUnlocalizedName(Names.Items.MINIUM_STONE);
-        this.setMaxDamage(1000); // TODO Get this from configs
+        this.setMaxDamage(Settings.Tools.miniumMaxDamage);
     }
 
     @Override

--- a/src/main/java/com/pahimar/ee3/reference/Messages.java
+++ b/src/main/java/com/pahimar/ee3/reference/Messages.java
@@ -32,5 +32,8 @@ public final class Messages
         public static final String SOUND_MODE = "soundMode";
         public static final String SOUND_MODE_LABEL = "general.sound.soundMode.label";
         public static final String SOUND_MODE_COMMENT = "general.sound.soundMode.comment";
+        
+        public static final String TOOL_MINIUM_STONE_MAX = "general.tools.miniumStoneMax";
+        public static final String TOOL_MINIUM_STONE_MAX_COMMENT = "general.tools.miniumStoneMax.comment";
     }
 }

--- a/src/main/java/com/pahimar/ee3/reference/Settings.java
+++ b/src/main/java/com/pahimar/ee3/reference/Settings.java
@@ -18,4 +18,9 @@ public class Settings
     {
         public static String soundMode;
     }
+    
+    public static class Tools
+    {
+    	public static int miniumMaxDamage;
+    }
 }

--- a/src/main/java/com/pahimar/ee3/skill/PlayerKnowledge.java
+++ b/src/main/java/com/pahimar/ee3/skill/PlayerKnowledge.java
@@ -1,7 +1,9 @@
 package com.pahimar.ee3.skill;
 
+import java.util.Set;
 import com.pahimar.ee3.reference.Names;
 import com.pahimar.ee3.util.INBTTaggable;
+import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 
 public class PlayerKnowledge implements INBTTaggable
@@ -16,6 +18,10 @@ public class PlayerKnowledge implements INBTTaggable
     public PlayerKnowledge(ItemTransmutationKnowledge itemTransmutationKnowledge)
     {
         this.itemTransmutationKnowledge = itemTransmutationKnowledge;
+    }
+    
+    public PlayerKnowledge(NBTTagCompound nbtTagCompound)
+    {
     }
 
     public ItemTransmutationKnowledge getItemTransmutationKnowledge()
@@ -60,6 +66,21 @@ public class PlayerKnowledge implements INBTTaggable
         playerKnowledge.readFromNBT(nbtTagCompound);
 
         return playerKnowledge;
+    }
+    
+    public Set<ItemStack> getKnownItemStacks()
+    {
+    	return itemTransmutationKnowledge.getKnownItemTransmutations();
+    }
+    
+    public boolean isItemStackKnown(ItemStack itemStack)
+    {
+    	return itemTransmutationKnowledge.isItemStackKnown(itemStack);
+    }
+    
+    public boolean learnItemStack(ItemStack itemStack)
+    {
+    	return itemTransmutationKnowledge.learnItemStack(itemStack);
     }
 
     @Override

--- a/src/main/java/com/pahimar/ee3/waila/WailaDataProvider.java
+++ b/src/main/java/com/pahimar/ee3/waila/WailaDataProvider.java
@@ -34,15 +34,15 @@ public class WailaDataProvider implements IWailaDataProvider
         }
         else if (accessor.getTileEntity() instanceof TileEntityAlchemicalChestSmall)
         {
-            currentTip.set(0, SpecialChars.WHITE + "Small Alchemical Chest"); // TODO: Localize
+            currentTip.set(0, SpecialChars.WHITE + StatCollector.translateToLocal("waila.ee3.smallAlchemicalChest"));
         }
         else if (accessor.getTileEntity() instanceof TileEntityAlchemicalChestMedium)
         {
-            currentTip.set(0, SpecialChars.WHITE + "Medium Alchemical Chest"); // TODO: Localize
+            currentTip.set(0, SpecialChars.WHITE + StatCollector.translateToLocal("waila.ee3.mediumAlchemicalChest"));
         }
         else if (accessor.getTileEntity() instanceof TileEntityAlchemicalChestLarge)
         {
-            currentTip.set(0, SpecialChars.WHITE + "Large Alchemical Chest"); // TODO: Localize
+            currentTip.set(0, SpecialChars.WHITE + StatCollector.translateToLocal("waila.ee3.largeAlchemicalChest"));
         }
 
         return currentTip;

--- a/src/main/resources/assets/ee3/lang/en_US.lang
+++ b/src/main/resources/assets/ee3/lang/en_US.lang
@@ -16,7 +16,7 @@ general.sound.soundMode.label=Sounds
 general.sound.soundMode.comment='All' plays mod sounds from all players, 'Self' only plays mod sounds from you, and 'None' plays no mod sounds
 
 general.tools.miniumStoneMax=Minium Stone Max Damage
-general.tools.miniumStoneMax.comment=Sets the Minium Stones max damage, between 1 - 9999
+general.tools.miniumStoneMax.comment=Sets the Minium Stones max damage
 
 # Keys
 key.categories.ee3=Equivalent Exchange 3

--- a/src/main/resources/assets/ee3/lang/en_US.lang
+++ b/src/main/resources/assets/ee3/lang/en_US.lang
@@ -15,6 +15,9 @@ general.transmutation.knowledge.template.comment=If true, new player's will have
 general.sound.soundMode.label=Sounds
 general.sound.soundMode.comment='All' plays mod sounds from all players, 'Self' only plays mod sounds from you, and 'None' plays no mod sounds
 
+general.tools.miniumStoneMax=Minium Stone Max Damage
+general.tools.miniumStoneMax.comment=Sets the Minium Stones max damage, between 1 - 9999
+
 # Keys
 key.categories.ee3=Equivalent Exchange 3
 key.charge=Charge
@@ -138,3 +141,8 @@ tooltip.ee3:alchemicalChestPrefix.small=Small
 tooltip.ee3:alchemicalChestPrefix.medium=Medium
 tooltip.ee3:alchemicalChestPrefix.large=Large
 tooltip.ee3:none=None
+
+# Waila
+waila.ee3.smallAlchemicalChest=Small Alchemical Chest
+waila.ee3.mediumAlchemicalChest=Medium Alchemical Chest
+waila.ee3.largeAlchemicalChest=Large Alchemical Chest


### PR DESCRIPTION
- Localized Alchemical Chest sizes for Waila (Changes to WailaDataProvider & en_us.lang)
- InventoryAlchemicalTome(ItemStack)
   - Changed so that if !ItemStack.hasTagCompound(), to return a new NBTTagCompound() instead of  returning ItemStack.getTagCompound()
- Get Minium maxDamage from Config (IDK if adding a label is relevant)
   - ItemMiniumStone
       - Changed setMaxDamage(1000) to setMaxDamage(Settings.Tools.miniumMaxDamage)
   - Settings
       - added a new class for Tools with new int for miniumMaxDamage
   - ConfigurationHandler
       - added new config option miniumMaxDamage, is set defaultValue to 1000, minDamage to 1, and  maxDamage at 9999
   - en_us.lang
       - Added Localization for minium stone max damage config options
   - Messages
       - Added Strings for Localizing minium Stone max Damage Config options

- TileEntityRendererGlassBell
   - Changes so that Ghost Item doesn't render when game is paused(or in
menu).
- PlayerKnowledge
   - Adds 3 methods and new constructor to *sudo* fix errors from latest
commit.

Edit: Not tested due to #757.