### PR TITLE
fixed tileentity UUID ownership

### DIFF
--- a/src/main/java/com/pahimar/ee3/tileentity/TileEntityEE.java
+++ b/src/main/java/com/pahimar/ee3/tileentity/TileEntityEE.java
@@ -109,7 +109,7 @@ public class TileEntityEE extends TileEntity
 
         if (nbtTagCompound.hasKey(Names.NBT.OWNER_UUID_MOST_SIG) && nbtTagCompound.hasKey(Names.NBT.OWNER_UUID_LEAST_SIG))
         {
-            this.ownerUUID = new UUID(nbtTagCompound.getLong(Names.NBT.OWNER_UUID_MOST_SIG), nbtTagCompound.getLong(Names.NBT.OWNER_UUID_MOST_SIG));
+            this.ownerUUID = new UUID(nbtTagCompound.getLong(Names.NBT.OWNER_UUID_MOST_SIG), nbtTagCompound.getLong(Names.NBT.OWNER_UUID_LEAST_SIG));
         }
     }
 


### PR DESCRIPTION
Title says it all. This isn't something that you would catch easily I suppose