### PR TITLE
Make the client launch in a clean dev checkout of EE3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -182,6 +182,14 @@ task copyChicken(type: Copy, dependsOn: "extractUserDev") {
 tasks.setupDevWorkspace.dependsOn copyChicken
 tasks.setupDecompWorkspace.dependsOn copyChicken
 
+// Stop MCP from crashing the client on every start. -.-'
+runClient {
+    args '--noCoreSearch'
+}
+runServer {
+    args '--noCoreSearch'
+}
+
 curse {
     dependsOn 'reobf'
     onlyIf { return project.hasProperty('ee3_curseforge_apikey') }


### PR DESCRIPTION
I believe ([twitter]) this is already in Pahimar's IDEA config, but without it here
too (or a README note) this doesn't propagate to anyone else.

After two days, about a dozen clean checkouts, three computers and many questions of my own sanity, I'm pretty sure that in a clean checkout, the client won't run without this. Please correct me if I'm wrong. :)

[twitter]: https://twitter.com/atomicblom/status/532190075858063360