### PR TITLE
Fix for dupe bug #885

### DIFF
--- a/src/main/java/com/pahimar/ee3/tileentity/TileEntityAlchemicalChest.java
+++ b/src/main/java/com/pahimar/ee3/tileentity/TileEntityAlchemicalChest.java
@@ -146,7 +146,7 @@ public class TileEntityAlchemicalChest extends TileEntityEE implements IInventor
     @Override
     public boolean isUseableByPlayer(EntityPlayer entityplayer)
     {
-        return true;
+        return this.worldObj.getTileEntity(xCoord, yCoord, zCoord) == this && entityplayer.getDistanceSq((double) xCoord + 0.5D, (double) yCoord + 0.5D, (double) zCoord + 0.5D) <= 64D;
     }
 
     @Override

--- a/src/main/java/com/pahimar/ee3/tileentity/TileEntityAludel.java
+++ b/src/main/java/com/pahimar/ee3/tileentity/TileEntityAludel.java
@@ -167,7 +167,7 @@ public class TileEntityAludel extends TileEntityEE implements ISidedInventory
     }
 
     @Override
-    public boolean isUseableByPlayer(EntityPlayer var1)
+    public boolean isUseableByPlayer(EntityPlayer entityPlayer)
     {
         return this.worldObj.getTileEntity(xCoord, yCoord, zCoord) == this && entityPlayer.getDistanceSq((double) xCoord + 0.5D, (double) yCoord + 0.5D, (double) zCoord + 0.5D) <= 64D;
     }

--- a/src/main/java/com/pahimar/ee3/tileentity/TileEntityAludel.java
+++ b/src/main/java/com/pahimar/ee3/tileentity/TileEntityAludel.java
@@ -169,7 +169,7 @@ public class TileEntityAludel extends TileEntityEE implements ISidedInventory
     @Override
     public boolean isUseableByPlayer(EntityPlayer var1)
     {
-        return true;
+        return this.worldObj.getTileEntity(xCoord, yCoord, zCoord) == this && entityPlayer.getDistanceSq((double) xCoord + 0.5D, (double) yCoord + 0.5D, (double) zCoord + 0.5D) <= 64D;
     }
 
     @Override

--- a/src/main/java/com/pahimar/ee3/tileentity/TileEntityAugmentationTable.java
+++ b/src/main/java/com/pahimar/ee3/tileentity/TileEntityAugmentationTable.java
@@ -101,7 +101,7 @@ public class TileEntityAugmentationTable extends TileEntityEE implements IInvent
     @Override
     public boolean isUseableByPlayer(EntityPlayer entityplayer)
     {
-        return true;
+        return this.worldObj.getTileEntity(xCoord, yCoord, zCoord) == this && entityplayer.getDistanceSq((double) xCoord + 0.5D, (double) yCoord + 0.5D, (double) zCoord + 0.5D) <= 64D;
     }
 
     @Override

--- a/src/main/java/com/pahimar/ee3/tileentity/TileEntityCalcinator.java
+++ b/src/main/java/com/pahimar/ee3/tileentity/TileEntityCalcinator.java
@@ -169,7 +169,7 @@ public class TileEntityCalcinator extends TileEntityEE implements ISidedInventor
     @Override
     public boolean isUseableByPlayer(EntityPlayer entityplayer)
     {
-        return true;
+        return this.worldObj.getTileEntity(xCoord, yCoord, zCoord) == this && entityplayer.getDistanceSq((double) xCoord + 0.5D, (double) yCoord + 0.5D, (double) zCoord + 0.5D) <= 64D;
     }
 
     @Override

--- a/src/main/java/com/pahimar/ee3/tileentity/TileEntityGlassBell.java
+++ b/src/main/java/com/pahimar/ee3/tileentity/TileEntityGlassBell.java
@@ -143,7 +143,7 @@ public class TileEntityGlassBell extends TileEntityEE implements IInventory
     @Override
     public boolean isUseableByPlayer(EntityPlayer entityPlayer)
     {
-        return true;
+        return this.worldObj.getTileEntity(xCoord, yCoord, zCoord) == this && entityPlayer.getDistanceSq((double) xCoord + 0.5D, (double) yCoord + 0.5D, (double) zCoord + 0.5D) <= 64D;
     }
 
     @Override

--- a/src/main/java/com/pahimar/ee3/tileentity/TileEntityResearchStation.java
+++ b/src/main/java/com/pahimar/ee3/tileentity/TileEntityResearchStation.java
@@ -109,7 +109,7 @@ public class TileEntityResearchStation extends TileEntityEE implements IInventor
     @Override
     public boolean isUseableByPlayer(EntityPlayer entityplayer)
     {
-        return true;
+        return this.worldObj.getTileEntity(xCoord, yCoord, zCoord) == this && entityplayer.getDistanceSq((double) xCoord + 0.5D, (double) yCoord + 0.5D, (double) zCoord + 0.5D) <= 64D;
     }
 
     @Override

--- a/src/main/java/com/pahimar/ee3/tileentity/TileEntityTransmutationTablet.java
+++ b/src/main/java/com/pahimar/ee3/tileentity/TileEntityTransmutationTablet.java
@@ -296,7 +296,7 @@ public class TileEntityTransmutationTablet extends TileEntityEE implements ISide
     @Override
     public boolean isUseableByPlayer(EntityPlayer entityPlayer)
     {
-        return true;
+        return this.worldObj.getTileEntity(xCoord, yCoord, zCoord) == this && entityPlayer.getDistanceSq((double) xCoord + 0.5D, (double) yCoord + 0.5D, (double) zCoord + 0.5D) <= 64D;
     }
 
     @Override


### PR DESCRIPTION
isUseableByPlayer now checks if the tile entity has changed or if the player is too far away instead of just returning true. The dupe bug would not occur as the gui of the container would close.