### PR TITLE
Fix DynEMC bugs #937 and #925

### DIFF
--- a/src/main/java/com/pahimar/ee3/EquivalentExchange3.java
+++ b/src/main/java/com/pahimar/ee3/EquivalentExchange3.java
@@ -85,7 +85,7 @@ public class EquivalentExchange3
 
         if (getEnergyValueRegistry().getFailed())
         {
-            LogHelper.error("An error occured while computing energy values.  EMC will not work.");
+            throw new RuntimeException("An error occured while computing energy values.", getEnergyValueRegistry().getError());
         }
     }
 

--- a/src/main/java/com/pahimar/ee3/EquivalentExchange3.java
+++ b/src/main/java/com/pahimar/ee3/EquivalentExchange3.java
@@ -66,6 +66,30 @@ public class EquivalentExchange3
     }
 
     @EventHandler
+    public void onServerStarted(FMLServerStartedEvent event)
+    {
+        synchronized (getEnergyValueRegistry())
+        {
+            try
+            {
+                if (!getEnergyValueRegistry().isReady())
+                {
+                    getEnergyValueRegistry().wait();
+                }
+            }
+            catch (InterruptedException ignored)
+            {
+
+            }
+        }
+
+        if (getEnergyValueRegistry().getFailed())
+        {
+            LogHelper.error("An error occured while computing energy values.  EMC will not work.");
+        }
+    }
+
+    @EventHandler
     public void preInit(FMLPreInitializationEvent event)
     {
         ConfigurationHandler.init(event.getSuggestedConfigurationFile());
@@ -125,6 +149,7 @@ public class EquivalentExchange3
         WorldEventHandler.hasInitilialized = false;
 
         EnergyValueRegistry.getInstance().save();
+        EnergyValueRegistry.getInstance().uninit();
         TransmutationKnowledgeRegistry.getInstance().clear();
         AbilityRegistry.getInstance().save();
     }

--- a/src/main/java/com/pahimar/ee3/exchange/DynamicEnergyValueInitThread.java
+++ b/src/main/java/com/pahimar/ee3/exchange/DynamicEnergyValueInitThread.java
@@ -16,12 +16,27 @@ public class DynamicEnergyValueInitThread implements Runnable
     @Override
     public void run()
     {
-        // Add in recipes to the RecipeRegistry *just* before we do calculations
-        RecipeRegistry.getInstance().registerVanillaRecipes();
-        AludelRecipeManager.registerRecipes();
+        try
+        {
+            // Add in recipes to the RecipeRegistry *just* before we do calculations
+            RecipeRegistry.getInstance().registerVanillaRecipes();
+            AludelRecipeManager.registerRecipes();
 
-        long startTime = System.currentTimeMillis();
-        EnergyValueRegistry.getInstance().init();
-        LogHelper.info(String.format("DynamicEMC system initialized after %s ms", System.currentTimeMillis() - startTime));
+            long startTime = System.currentTimeMillis();
+            EnergyValueRegistry.getInstance().init();
+            LogHelper.info(String.format("DynamicEMC system initialized after %s ms", System.currentTimeMillis() - startTime));
+        }
+        catch (Throwable t)
+        {
+            EnergyValueRegistry.getInstance().setFailed(t);
+        }
+        finally
+        {
+            synchronized (EnergyValueRegistry.getInstance())
+            {
+                EnergyValueRegistry.getInstance().makeReady();
+                EnergyValueRegistry.getInstance().notifyAll();
+            }
+        }
     }
 }

--- a/src/main/java/com/pahimar/ee3/exchange/WrappedStack.java
+++ b/src/main/java/com/pahimar/ee3/exchange/WrappedStack.java
@@ -461,7 +461,7 @@ public class WrappedStack implements Comparable<WrappedStack>, JsonDeserializer<
 
         if (wrappedStack instanceof ItemStack)
         {
-            hashCode = (37 * hashCode) + Item.getIdFromItem(((ItemStack) wrappedStack).getItem());
+            hashCode = (37 * hashCode) + Item.itemRegistry.getNameForObject(((ItemStack) wrappedStack).getItem()).hashCode();
             hashCode = (37 * hashCode) + ((ItemStack) wrappedStack).getItemDamage();
 
             if (((ItemStack) wrappedStack).getTagCompound() != null)
@@ -478,7 +478,7 @@ public class WrappedStack implements Comparable<WrappedStack>, JsonDeserializer<
         }
         else if (wrappedStack instanceof FluidStack)
         {
-            hashCode = (37 * hashCode) + wrappedStack.hashCode();
+            hashCode = (37 * hashCode) + ((FluidStack)wrappedStack).getFluid().getName().hashCode();
 
             if (((FluidStack) wrappedStack).tag != null)
             {
@@ -556,7 +556,6 @@ public class WrappedStack implements Comparable<WrappedStack>, JsonDeserializer<
         @Override
         public int compare(WrappedStack wrappedStack1, WrappedStack wrappedStack2)
         {
-
             if (wrappedStack1.wrappedStack instanceof ItemStack)
             {
                 if (wrappedStack2.wrappedStack instanceof ItemStack)

--- a/src/main/java/com/pahimar/ee3/reference/Comparators.java
+++ b/src/main/java/com/pahimar/ee3/reference/Comparators.java
@@ -25,7 +25,7 @@ public class Comparators
             if (itemStack1 != null && itemStack2 != null)
             {
                 // Sort on itemID
-                if (Item.getIdFromItem(itemStack1.getItem()) - Item.getIdFromItem(itemStack2.getItem()) == 0)
+                if (Item.itemRegistry.getNameForObject(itemStack1.getItem()).compareToIgnoreCase(Item.itemRegistry.getNameForObject(itemStack2.getItem())) == 0)
                 {
                     // Sort on item
                     if (itemStack1.getItem() == itemStack2.getItem())
@@ -71,7 +71,7 @@ public class Comparators
                 }
                 else
                 {
-                    return Item.getIdFromItem(itemStack1.getItem()) - Item.getIdFromItem(itemStack2.getItem());
+                    return Item.itemRegistry.getNameForObject(itemStack1.getItem()).compareToIgnoreCase(Item.itemRegistry.getNameForObject(itemStack2.getItem()));
                 }
             }
             else if (itemStack1 != null)

--- a/src/main/java/com/pahimar/ee3/util/FluidHelper.java
+++ b/src/main/java/com/pahimar/ee3/util/FluidHelper.java
@@ -23,7 +23,7 @@ public class FluidHelper
                 if (fluidStack2 != null)
                 {
                     //                    if (fluidStack1.fluidID == fluidStack2.fluidID)
-                    if (FluidRegistry.getFluidID(fluidStack1.getFluid()) == FluidRegistry.getFluidID(fluidStack2.getFluid()))
+                    if (fluidStack1.getFluid().getName().compareToIgnoreCase(fluidStack2.getFluid().getName()) == 0)
                     {
                         if (fluidStack1.amount == fluidStack2.amount)
                         {
@@ -57,7 +57,7 @@ public class FluidHelper
                     }
                     else
                     {
-                        return (FluidRegistry.getFluidID(fluidStack1.getFluid()) - FluidRegistry.getFluidID(fluidStack2.getFluid()));
+                        return (fluidStack1.getFluid().getName().compareToIgnoreCase(fluidStack2.getFluid().getName()));
                     }
                 }
                 else

--- a/src/main/java/com/pahimar/ee3/util/ItemHelper.java
+++ b/src/main/java/com/pahimar/ee3/util/ItemHelper.java
@@ -35,7 +35,7 @@ public class ItemHelper
         if (itemStack1 != null && itemStack2 != null)
         {
             // Sort on itemID
-            if (Item.getIdFromItem(itemStack1.getItem()) - Item.getIdFromItem(itemStack2.getItem()) == 0)
+            if (Item.itemRegistry.getNameForObject(itemStack1.getItem()).compareToIgnoreCase(Item.itemRegistry.getNameForObject(itemStack2.getItem())) == 0)
             {
                 // Sort on item
                 if (itemStack1.getItem() == itemStack2.getItem())
@@ -137,5 +137,4 @@ public class ItemHelper
     {
         NBTHelper.setString(itemStack, Names.NBT.OWNER, entityPlayer.getDisplayName());
     }
-
 }


### PR DESCRIPTION
This fixes a NullPointerException caused when the energy value treemap returned null after a failed lookup.  Because EE3 is currently using item IDs to define sort order and FML changes item IDs when a save is loaded, the treemap gets confused and cannot find most of its keys.  The comparisons are changed to use the FML registered name (example: minecraft:stone) rather than the IDs.

This also fixes the duplicate fluidstack issue by using the name of the fluid for the hash code instead of ```FluidStack.hashCode()```.  Because a FluidStack's hash code is based on the Fluid object and PneumaticCraft uses its own Fluid object regardless of whether or not one for that fluid is already registered, it creates two distinct FluidStacks of oil/fuel, which were seen as the same when the immutable recipe map was created, hence the duplicate key error.

This also adds synchronization so that EE3 waits in the FMLServerStartedEvent until DynEMC is finished calculating.  This prevents premature serialization of the energy value map, which was causing a NPE when it attempted to serialize null.