### PR TITLE
Fix for IO Exception reading model format WavefrontObject.class

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,7 +1,7 @@
 #
 #Sat Dec 28 00:14:08 EST 2013
 minecraft_version = 1.7.10
-forge_version = 10.13.3.1399-1.7.10
+forge_version = 10.13.4.1492-1.7.10
 mod_version = 0.3
 api_version = 1.3
 release_type = beta


### PR DESCRIPTION
Fix for can't reading models with upgrading forge version

but there is a little problem in this fix i explained in #1000 
fixes #1000 