### PR TITLE
Fix java 8 because of remove sun internal Nullable annotation

### DIFF
--- a/src/main/java/com/pahimar/ee/tileentity/TileEntityBase.java
+++ b/src/main/java/com/pahimar/ee/tileentity/TileEntityBase.java
@@ -1,12 +1,12 @@
 package com.pahimar.ee.tileentity;
 
 import com.pahimar.ee.reference.Names;
-import com.sun.istack.internal.Nullable;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ITickable;
 
+import javax.annotation.Nullable;
 import java.util.UUID;
 
 public abstract class TileEntityBase extends TileEntity implements ITickable {


### PR DESCRIPTION
The annotation com.sun.istack.internal.Nullable was removed in java 8.
In order to compile with java 8 this type can't be used.